### PR TITLE
Zoom and pan limits

### DIFF
--- a/src/chart.zoom.js
+++ b/src/chart.zoom.js
@@ -494,5 +494,3 @@ var zoomPlugin = {
 };
 
 Chart.pluginService.register(zoomPlugin);
-
-},{"chart.js":1,"hammerjs":1}]},{},[2]);


### PR DESCRIPTION
Add xmin, xmax, ymin and ymax zoom and pan limits for numeric and time scales. The limits are supposed to be set as members of options.zoom.limits object, e.g. options.zoom.limits.xmin

Resolves #37 
