### PR TITLE
Suppress ghost click after panning

### DIFF
--- a/samples/zoom.html
+++ b/samples/zoom.html
@@ -138,6 +138,9 @@
 							max: 10,
 							min: 0.5
 						}
+					},
+					onClick: function(e) {
+						alert(e.type);
 					}
 				}
 			});

--- a/src/chart.zoom.js
+++ b/src/chart.zoom.js
@@ -386,9 +386,10 @@ var zoomPlugin = {
 				zoomNS.zoomCumulativeDelta = 0;
 			});
 
-			var currentDeltaX = null, currentDeltaY = null;
+			var currentDeltaX = null, currentDeltaY = null, panning = false;
 			var handlePan = function handlePan(e) {
 				if (currentDeltaX !== null && currentDeltaY !== null) {
+					panning = true;
 					var deltaX = e.deltaX - currentDeltaX;
 					var deltaY = e.deltaY - currentDeltaY;
 					currentDeltaX = e.deltaX;
@@ -407,7 +408,17 @@ var zoomPlugin = {
 				currentDeltaX = null;
 				currentDeltaY = null;
 				zoomNS.panCumulativeDelta = 0;
+				setTimeout(function() { panning = false; }, 500);
 			});
+
+			chartInstance.zoom._ghostClickHandler = function(e) {
+				if (panning) {
+					e.stopImmediatePropagation();
+					e.preventDefault();
+				}
+			};
+			node.addEventListener('click', chartInstance.zoom._ghostClickHandler);
+
 			chartInstance._mc = mc;
 		}
 	},
@@ -452,6 +463,10 @@ var zoomPlugin = {
 				node.removeEventListener('mouseup', chartInstance.zoom._mouseUpHandler);
 			} else {
 				node.removeEventListener('wheel', chartInstance.zoom._wheelHandler);
+			}
+
+			if (Hammer) {
+				node.removeEventListener('click', chartInstance.zoom._ghostClickHandler);
 			}
 
 			delete chartInstance.zoom;


### PR DESCRIPTION
A `click` event was emitted at the end of the `pan` gesture. This suppresses the click which originates from the `mouseup`, but allows it if the user did not drag the mouse. This is comparable to how [d3-drag](https://github.com/d3/d3-drag) behaves.