### PR TITLE
Added support for setting lower/upper limit for zoom/pan range

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 		// Eg. 'y' would only allow panning in the y direction
 		mode: 'xy',
 		rangeMin: {
-		    // Format of min zoom range depends on scale type
-		    x: null,
-		    y: null
+			// Format of min pan range depends on scale type
+			x: null,
+			y: null
 		},
-        rangeMax: {
-            // Format of max zoom range depends on scale type
-            x: null,
-            y: null
-        }
+		rangeMax: {
+			// Format of max pan range depends on scale type
+			x: null,
+			y: null
+		}
 	},
 	
 	// Container for zoom options
@@ -42,14 +42,14 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 		// Eg. 'y' would only allow zooming in the y direction
 		mode: 'xy',
 		rangeMin: {
-            // Format of min zoom range depends on scale type
-            x: null,
-            y: null
+			// Format of min zoom range depends on scale type
+			x: null,
+			y: null
 		},
 		rangeMax: {
-            // Format of max zoom range depends on scale type
-            x: null,
-            y: null
+			// Format of max zoom range depends on scale type
+			x: null,
+			y: null
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 		    x: null,
 		    y: null
 		},
-		rangeMax: {
-		    // Format of max zoom range depends on scale type
+        rangeMax: {
+            // Format of max zoom range depends on scale type
             x: null,
             y: null
-		}
+        }
 	},
 	
 	// Container for zoom options
@@ -42,12 +42,12 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 		// Eg. 'y' would only allow zooming in the y direction
 		mode: 'xy',
 		rangeMin: {
-		    // Format of min zoom range depends on scale type
-		    x: null,
-		    y: null
+            // Format of min zoom range depends on scale type
+            x: null,
+            y: null
 		},
 		rangeMax: {
-		    // Format of max zoom range depends on scale type
+            // Format of max zoom range depends on scale type
             x: null,
             y: null
 		}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 
 		// Panning directions. Remove the appropriate direction to disable 
 		// Eg. 'y' would only allow panning in the y direction
-		mode: 'xy'
+		mode: 'xy',
+		rangeMin: {
+		    // Format of min zoom range depends on scale type
+		    x: null,
+		    y: null
+		},
+		rangeMax: {
+		    // Format of max zoom range depends on scale type
+            x: null,
+            y: null
+		}
 	},
 	
 	// Container for zoom options
@@ -31,6 +41,16 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 		// Zooming directions. Remove the appropriate direction to disable 
 		// Eg. 'y' would only allow zooming in the y direction
 		mode: 'xy',
+		rangeMin: {
+		    // Format of min zoom range depends on scale type
+		    x: null,
+		    y: null
+		},
+		rangeMax: {
+		    // Format of max zoom range depends on scale type
+            x: null,
+            y: null
+		}
 	}
 }
 ```

--- a/src/chart.zoom.js
+++ b/src/chart.zoom.js
@@ -23,12 +23,12 @@ var defaultOptions = zoomNS.defaults = {
 		enabled: true,
 		mode: 'xy',
 		speed: 20,
-		threshold: 10,
+		threshold: 10
 	},
 	zoom: {
 		enabled: true,
 		mode: 'xy',
-		sensitivity: 3,
+		sensitivity: 3
 	}
 };
 
@@ -40,6 +40,26 @@ function directionEnabled(mode, dir) {
 	}
 
 	return false;
+}
+
+function rangeMaxLimiter(zoomPanOptions, newMax) {
+	if (zoomPanOptions.scaleAxes && zoomPanOptions.rangeMax && zoomPanOptions.rangeMax[zoomPanOptions.scaleAxes]) {
+		var rangeMax = zoomPanOptions.rangeMax[zoomPanOptions.scaleAxes];
+        if (newMax > rangeMax) {
+            newMax = rangeMax;
+        }
+    }
+    return newMax;
+}
+
+function rangeMinLimiter(zoomPanOptions, newMin) {
+    if (zoomPanOptions.scaleAxes && zoomPanOptions.rangeMax && zoomPanOptions.rangeMax[zoomPanOptions.scaleAxes]) {
+    	var rangeMin = zoomPanOptions.rangeMin[zoomPanOptions.scaleAxes];
+        if (newMin < rangeMin) {
+            newMin = rangeMin;
+        }
+    }
+    return newMin;
 }
 
 function zoomIndexScale(scale, zoom, center, zoomOptions) {
@@ -78,12 +98,12 @@ function zoomIndexScale(scale, zoom, center, zoomOptions) {
 			}
 			zoomNS.zoomCumulativeDelta = 0;
 		}
-		scale.options.ticks.min = labels[minIndex];
-		scale.options.ticks.max = labels[maxIndex];
+		scale.options.ticks.min = rangeMinLimiter(zoomOptions, labels[minIndex]);
+		scale.options.ticks.max = rangeMaxLimiter(zoomOptions, labels[maxIndex]);
 	}
 }
 
-function zoomTimeScale(scale, zoom, center) {
+function zoomTimeScale(scale, zoom, center, zoomOptions) {
 	var options = scale.options;
 
 	var range;
@@ -102,11 +122,11 @@ function zoomTimeScale(scale, zoom, center) {
 	var minDelta = newDiff * min_percent;
 	var maxDelta = newDiff * max_percent;
 
-	options.time.min = scale.getValueForPixel(scale.getPixelForValue(scale.firstTick) + minDelta);
-	options.time.max = scale.getValueForPixel(scale.getPixelForValue(scale.lastTick) - maxDelta);
+	options.time.min = rangeMinLimiter(zoomOptions, scale.getValueForPixel(scale.getPixelForValue(scale.firstTick) + minDelta));
+	options.time.max = rangeMaxLimiter(zoomOptions, scale.getValueForPixel(scale.getPixelForValue(scale.lastTick) - maxDelta));
 }
 
-function zoomNumericalScale(scale, zoom, center) {
+function zoomNumericalScale(scale, zoom, center, zoomOptions) {
 	var range = scale.max - scale.min;
 	var newDiff = range * (zoom - 1);
 
@@ -117,8 +137,8 @@ function zoomNumericalScale(scale, zoom, center) {
 	var minDelta = newDiff * min_percent;
 	var maxDelta = newDiff * max_percent;
 
-	scale.options.ticks.min = scale.min + minDelta;
-	scale.options.ticks.max = scale.max - maxDelta;
+	scale.options.ticks.min = rangeMinLimiter(zoomOptions, scale.min + minDelta);
+	scale.options.ticks.max = rangeMaxLimiter(zoomOptions, scale.max - maxDelta);
 }
 
 function zoomScale(scale, zoom, center, zoomOptions) {
@@ -146,9 +166,11 @@ function doZoom(chartInstance, zoom, center) {
 
 		helpers.each(chartInstance.scales, function(scale, id) {
 			if (scale.isHorizontal() && directionEnabled(zoomMode, 'x')) {
+				zoomOptions.scaleAxes = "x";
 				zoomScale(scale, zoom, center, zoomOptions);
 			} else if (!scale.isHorizontal() && directionEnabled(zoomMode, 'y')) {
 				// Do Y zoom
+				zoomOptions.scaleAxes = "y";
 				zoomScale(scale, zoom, center, zoomOptions);
 			}
 		});
@@ -173,17 +195,17 @@ function panIndexScale(scale, delta, panOptions) {
 
 	maxIndex = Math.min(lastLabelIndex, minIndex + offsetAmt - 1);
 
-	scale.options.ticks.min = labels[minIndex];
-	scale.options.ticks.max = labels[maxIndex];
+	scale.options.ticks.min = rangeMinLimiter(panOptions, labels[minIndex]);
+	scale.options.ticks.max = rangeMaxLimiter(panOptions, labels[maxIndex]);
 }
 
-function panTimeScale(scale, delta) {
+function panTimeScale(scale, delta, panOptions) {
 	var options = scale.options;
-	options.time.min = scale.getValueForPixel(scale.getPixelForValue(scale.firstTick) - delta);
-	options.time.max = scale.getValueForPixel(scale.getPixelForValue(scale.lastTick) - delta);
+	options.time.min = rangeMinLimiter(panOptions, scale.getValueForPixel(scale.getPixelForValue(scale.firstTick) - delta));
+	options.time.max = rangeMaxLimiter(panOptions, scale.getValueForPixel(scale.getPixelForValue(scale.lastTick) - delta));
 }
 
-function panNumericalScale(scale, delta) {
+function panNumericalScale(scale, delta, panOptions) {
 	var tickOpts = scale.options.ticks;
 	var start = scale.start,
 		end = scale.end;
@@ -195,6 +217,8 @@ function panNumericalScale(scale, delta) {
 		tickOpts.min = scale.getValueForPixel(scale.getPixelForValue(start) - delta);
 		tickOpts.max = scale.getValueForPixel(scale.getPixelForValue(end) - delta);
 	}
+    tickOpts.min = rangeMinLimiter(panOptions, tickOpts.min);
+	tickOpts.max = rangeMaxLimiter(panOptions, tickOpts.max);
 }
 
 function panScale(scale, delta, panOptions) {
@@ -212,8 +236,10 @@ function doPan(chartInstance, deltaX, deltaY) {
 
 		helpers.each(chartInstance.scales, function(scale, id) {
 			if (scale.isHorizontal() && directionEnabled(panMode, 'x') && deltaX !== 0) {
+				panOptions.scaleAxes = "x";
 				panScale(scale, deltaX, panOptions);
 			} else if (!scale.isHorizontal() && directionEnabled(panMode, 'y') && deltaY !== 0) {
+                panOptions.scaleAxes = "y";
 				panScale(scale, deltaY, panOptions);
 			}
 		});

--- a/src/chart.zoom.js
+++ b/src/chart.zoom.js
@@ -53,7 +53,7 @@ function rangeMaxLimiter(zoomPanOptions, newMax) {
 }
 
 function rangeMinLimiter(zoomPanOptions, newMin) {
-    if (zoomPanOptions.scaleAxes && zoomPanOptions.rangeMax && zoomPanOptions.rangeMax[zoomPanOptions.scaleAxes]) {
+    if (zoomPanOptions.scaleAxes && zoomPanOptions.rangeMin && zoomPanOptions.rangeMin[zoomPanOptions.scaleAxes]) {
     	var rangeMin = zoomPanOptions.rangeMin[zoomPanOptions.scaleAxes];
         if (newMin < rangeMin) {
             newMin = rangeMin;


### PR DESCRIPTION
I added two functions for enforcing the limits and ensured they are called by all zoom/pan functions.
To support both x and y directions, I supplied the detected direction with the options object before passing it along.
The solutions works excellently in my case with a horizontal timescale graph, but I haven't tested it with other scale types, but in theory it should handle that too as it is.
The README.MD file was updated to include the new range settings.
Hope you find this useful - let me know if you have any questions :)