### PR TITLE
Should not listen for 'wheel' event if zoom is not enabled.

### DIFF
--- a/chartjs-plugin-zoom.js
+++ b/chartjs-plugin-zoom.js
@@ -374,7 +374,7 @@ var zoomPlugin = {
 				}
 			};
 			node.addEventListener('mouseup', chartInstance.zoom._mouseUpHandler);
-		} else {
+		} else if (options.zoom.enabled) {
 			chartInstance.zoom._wheelHandler = function(event) {
 				var rect = event.target.getBoundingClientRect();
 				var offsetX = event.clientX - rect.left;
@@ -499,7 +499,7 @@ var zoomPlugin = {
 				node.removeEventListener('mousedown', chartInstance.zoom._mouseDownHandler);
 				node.removeEventListener('mousemove', chartInstance.zoom._mouseMoveHandler);
 				node.removeEventListener('mouseup', chartInstance.zoom._mouseUpHandler);
-			} else {
+			} else if (options.zoom.enabled) {
 				node.removeEventListener('wheel', chartInstance.zoom._wheelHandler);
 			}
 


### PR DESCRIPTION
This 2 additional checks are here to fixes the issue #77 that occurs when you load the chartjs-zoom plugin and choose to not apply it to every chart on the page, then the 'wheel' event listener will still listen for all charts, preventing for a normal scroll behaviour on charts.
Thanks for merging ASAP !
=)
