### PR TITLE
Fix pinch center calculation closes #93

### DIFF
--- a/src/chart.zoom.js
+++ b/src/chart.zoom.js
@@ -396,7 +396,15 @@ var zoomPlugin = {
 			var currentPinchScaling;
 			var handlePinch = function handlePinch(e) {
 				var diff = 1 / (currentPinchScaling) * e.scale;
-				doZoom(chartInstance, diff, e.center);
+				var rect = e.target.getBoundingClientRect();
+				var offsetX = e.center.x - rect.left;
+				var offsetY = e.center.y - rect.top;
+				var center = {
+					x : offsetX,
+					y : offsetY
+				};
+
+				doZoom(chartInstance, diff, center);
 
 				// Keep track of overall scale
 				currentPinchScaling = e.scale;


### PR DESCRIPTION
The center point used for pinch isn't competely correct when the chart is not aligned left.
For wheel event a correction is made using getBoundingClientRect().
I copied the code to the function `handlePinch` and it was working perfectly fine in my use case.
This should close #93 

Best wishes
MeisterLampe