### PR TITLE
Add options to customize drag-to-zoom area

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ To configure the zoom and pan plugin, you can simply add new config options to y
 		// Enable drag-to-zoom behavior
 		drag: true,
 
+		// Drag-to-zoom rectangle style can be customized
+		// drag: {
+		// 	 borderColor: 'rgba(225,225,225,0.3)'
+		// 	 borderWidth: 5,
+		// 	 backgroundColor: 'rgb(225,225,225)'
+		// },
+
 		// Zooming directions. Remove the appropriate direction to disable 
 		// Eg. 'y' would only allow zooming in the y direction
 		mode: 'xy',

--- a/src/chart.zoom.js
+++ b/src/chart.zoom.js
@@ -565,10 +565,16 @@ var zoomPlugin = {
 
 			var rectWidth = endX - startX;
 			var rectHeight = endY - startY;
+			var dragOptions = chartInstance.options.zoom.drag;
 
-			ctx.fillStyle = 'rgba(225,225,225,0.3)';
-			ctx.lineWidth = 5;
+			ctx.fillStyle = dragOptions.backgroundColor || 'rgba(225,225,225,0.3)';
 			ctx.fillRect(startX, startY, rectWidth, rectHeight);
+
+			if (dragOptions.borderWidth > 0) {
+				ctx.lineWidth = dragOptions.borderWidth;
+				ctx.strokeStyle = dragOptions.borderColor || 'rgba(225,225,225)';
+				ctx.strokeRect(startX, startY, rectWidth, rectHeight);
+			}
 		}
 
 		ctx.rect(chartArea.left, chartArea.top, chartArea.right - chartArea.left, chartArea.bottom - chartArea.top);


### PR DESCRIPTION
Hi,

This PR adds options to customize drag-to-zoom rectangle area:

```js
{
  zoom: {
    drag: {
      borderColor: 'rgba(225,225,225,0.3)'
      borderWidth: 5,
      backgroundColor: 'rgb(225,225,225)'
    }
  }
}
```

Closes #106 