### PR TITLE
Allow switching between wheel/drag modes of the zoom

### DIFF
--- a/samples/zoom-time.html
+++ b/samples/zoom-time.html
@@ -45,16 +45,10 @@
 			return window.moment().add(days, 'd').format(timeFormat);
 		}
 
-		/**
-		 * Reset the zoom.
-		 */
 		function resetZoom() {
 			window.myLine.resetZoom();
 		}
 
-		/**
-		 * Toggle the `drag` mode of the zoom.
-		 */
 		function toggleDragMode() {
 			var zoomOptions = window.myLine.options.zoom;
 			zoomOptions.drag = !zoomOptions.drag;

--- a/samples/zoom-time.html
+++ b/samples/zoom-time.html
@@ -19,6 +19,7 @@
 <body>
 	<div style="width:75%;">
 		<button onclick="resetZoom()">Reset Zoom</button>
+		<button id="drag-switch" onclick="toggleDragMode()">Disable drag mode</button>
 		<canvas id="canvas"></canvas>
 	</div>
 	<script>
@@ -42,6 +43,22 @@
 
 		function newDateString(days) {
 			return window.moment().add(days, 'd').format(timeFormat);
+		}
+
+		/**
+		 * Reset the zoom.
+		 */
+		function resetZoom() {
+			window.myLine.resetZoom();
+		}
+
+		/**
+		 * Toggle the `drag` mode of the zoom.
+		 */
+		function toggleDragMode() {
+			var zoomOptions = window.myLine.options.zoom;
+			zoomOptions.drag = !zoomOptions.drag;
+			document.getElementById('drag-switch').innerText = zoomOptions.drag ? 'Disable drag mode' : 'Enable drag mode';
 		}
 
 		var config = {
@@ -126,7 +143,6 @@
 		window.onload = function() {
 			var ctx = document.getElementById('canvas').getContext('2d');
 			window.myLine = new window.Chart(ctx, config);
-
 		};
 	</script>
 </body>

--- a/samples/zoom-time.html
+++ b/samples/zoom-time.html
@@ -45,16 +45,6 @@
 			return window.moment().add(days, 'd').format(timeFormat);
 		}
 
-		function resetZoom() {
-			window.myLine.resetZoom();
-		}
-
-		function toggleDragMode() {
-			var zoomOptions = window.myLine.options.zoom;
-			zoomOptions.drag = !zoomOptions.drag;
-			document.getElementById('drag-switch').innerText = zoomOptions.drag ? 'Disable drag mode' : 'Enable drag mode';
-		}
-
 		var config = {
 			type: 'line',
 			data: {
@@ -133,6 +123,16 @@
 			dataset.pointBackgroundColor = randomColor(0.5);
 			dataset.pointBorderWidth = 1;
 		});
+
+		window.resetZoom = function() {
+			window.myLine.resetZoom();
+		};
+
+		window.toggleDragMode = function() {
+			var zoomOptions = window.myLine.options.zoom;
+			zoomOptions.drag = !zoomOptions.drag;
+			document.getElementById('drag-switch').innerText = zoomOptions.drag ? 'Disable drag mode' : 'Enable drag mode';
+		};
 
 		window.onload = function() {
 			var ctx = document.getElementById('canvas').getContext('2d');

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -367,6 +367,7 @@ var zoomPlugin = {
 
 		chartInstance.zoom._mouseDownHandler = function(event) {
 			if (chartInstance.options.zoom.drag) {
+				node.addEventListener('mousemove', chartInstance.zoom._mouseMoveHandler);
 				chartInstance.zoom._dragZoomStart = event;
 			}
 		};
@@ -378,49 +379,52 @@ var zoomPlugin = {
 				chartInstance.update(0);
 			}
 		};
-		node.addEventListener('mousemove', chartInstance.zoom._mouseMoveHandler);
 
 		chartInstance.zoom._mouseUpHandler = function(event) {
-			if (chartInstance.options.zoom.drag && chartInstance.zoom._dragZoomStart) {
-				var chartArea = chartInstance.chartArea;
-				var xAxis = getXAxis(chartInstance);
-				var yAxis = getYAxis(chartInstance);
-				var beginPoint = chartInstance.zoom._dragZoomStart;
-				var startX = xAxis.left;
-				var endX = xAxis.right;
-				var startY = yAxis.top;
-				var endY = yAxis.bottom;
+			if (!chartInstance.options.zoom.drag || !chartInstance.zoom._dragZoomStart) {
+				return;
+			}
 
-				if (directionEnabled(chartInstance.options.zoom.mode, 'x')) {
-					var offsetX = beginPoint.target.getBoundingClientRect().left;
-					startX = Math.min(beginPoint.clientX, event.clientX) - offsetX;
-					endX = Math.max(beginPoint.clientX, event.clientX) - offsetX;
-				}
+			node.removeEventListener('mousemove', chartInstance.zoom._mouseMoveHandler);
 
-				if (directionEnabled(chartInstance.options.zoom.mode, 'y')) {
-					var offsetY = beginPoint.target.getBoundingClientRect().top;
-					startY = Math.min(beginPoint.clientY, event.clientY) - offsetY;
-					endY = Math.max(beginPoint.clientY, event.clientY) - offsetY;
-				}
+			var chartArea = chartInstance.chartArea;
+			var xAxis = getXAxis(chartInstance);
+			var yAxis = getYAxis(chartInstance);
+			var beginPoint = chartInstance.zoom._dragZoomStart;
+			var startX = xAxis.left;
+			var endX = xAxis.right;
+			var startY = yAxis.top;
+			var endY = yAxis.bottom;
 
-				var dragDistanceX = endX - startX;
-				var chartDistanceX = chartArea.right - chartArea.left;
-				var zoomX = 1 + ((chartDistanceX - dragDistanceX) / chartDistanceX);
+			if (directionEnabled(chartInstance.options.zoom.mode, 'x')) {
+				var offsetX = beginPoint.target.getBoundingClientRect().left;
+				startX = Math.min(beginPoint.clientX, event.clientX) - offsetX;
+				endX = Math.max(beginPoint.clientX, event.clientX) - offsetX;
+			}
 
-				var dragDistanceY = endY - startY;
-				var chartDistanceY = chartArea.bottom - chartArea.top;
-				var zoomY = 1 + ((chartDistanceY - dragDistanceY) / chartDistanceY);
+			if (directionEnabled(chartInstance.options.zoom.mode, 'y')) {
+				var offsetY = beginPoint.target.getBoundingClientRect().top;
+				startY = Math.min(beginPoint.clientY, event.clientY) - offsetY;
+				endY = Math.max(beginPoint.clientY, event.clientY) - offsetY;
+			}
 
-				// Remove drag start and end before chart update to stop drawing selected area
-				chartInstance.zoom._dragZoomStart = null;
-				chartInstance.zoom._dragZoomEnd = null;
+			var dragDistanceX = endX - startX;
+			var chartDistanceX = chartArea.right - chartArea.left;
+			var zoomX = 1 + ((chartDistanceX - dragDistanceX) / chartDistanceX);
 
-				if (dragDistanceX > 0 || dragDistanceY > 0) {
-					doZoom(chartInstance, zoomX, zoomY, {
-						x: (startX - chartArea.left) / (1 - dragDistanceX / chartDistanceX) + chartArea.left,
-						y: (startY - chartArea.top) / (1 - dragDistanceY / chartDistanceY) + chartArea.top
-					});
-				}
+			var dragDistanceY = endY - startY;
+			var chartDistanceY = chartArea.bottom - chartArea.top;
+			var zoomY = 1 + ((chartDistanceY - dragDistanceY) / chartDistanceY);
+
+			// Remove drag start and end before chart update to stop drawing selected area
+			chartInstance.zoom._dragZoomStart = null;
+			chartInstance.zoom._dragZoomEnd = null;
+
+			if (dragDistanceX > 0 || dragDistanceY > 0) {
+				doZoom(chartInstance, zoomX, zoomY, {
+					x: (startX - chartArea.left) / (1 - dragDistanceX / chartDistanceX) + chartArea.left,
+					y: (startY - chartArea.top) / (1 - dragDistanceY / chartDistanceY) + chartArea.top
+				});
 			}
 		};
 		node.ownerDocument.addEventListener('mouseup', chartInstance.zoom._mouseUpHandler);


### PR DESCRIPTION
Closes #176 

This PR allows switching between wheel/drag modes of the zoom (if `options.zoom.drag` is changed, it will be taken into account in next events).

- All event listeners are set up in the `beforeInit` method, and the `options.zoom.drag` setting is checked in the body of these listeners rather than at the initialization.
- I added a `Enable/disable drag mode` in the `zoom-time` sample to test this improvement.
- I also fixed the `Reset Zoom` button in the `zoom-time` sample.