### PR TITLE
Fix zooming clears logarithmic scale

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -132,6 +132,7 @@ function zoomTimeScale(scale, zoom, center, zoomOptions) {
 }
 
 function zoomNumericalScale(scale, zoom, center, zoomOptions) {
+	var tickOpts = scale.options.ticks;
 	var range = scale.max - scale.min;
 	var newDiff = range * (zoom - 1);
 
@@ -141,6 +142,10 @@ function zoomNumericalScale(scale, zoom, center, zoomOptions) {
 
 	var minDelta = newDiff * minPercent;
 	var maxDelta = newDiff * maxPercent;
+
+	if (scale.type === 'logarithmic') {
+		tickOpts.min = tickOpts.min < 0 ? 0 : tickOpts.min;
+	}
 
 	scale.options.ticks.min = rangeMinLimiter(zoomOptions, scale.min + minDelta);
 	scale.options.ticks.max = rangeMaxLimiter(zoomOptions, scale.max - maxDelta);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -143,12 +143,15 @@ function zoomNumericalScale(scale, zoom, center, zoomOptions) {
 	var minDelta = newDiff * minPercent;
 	var maxDelta = newDiff * maxPercent;
 
+	tickOpts.min = scale.min + minDelta;
+	tickOpts.max = scale.max - maxDelta;
+
 	if (scale.type === 'logarithmic') {
 		tickOpts.min = tickOpts.min < 0 ? 0 : tickOpts.min;
 	}
 
-	scale.options.ticks.min = rangeMinLimiter(zoomOptions, scale.min + minDelta);
-	scale.options.ticks.max = rangeMaxLimiter(zoomOptions, scale.max - maxDelta);
+	tickOpts.min = rangeMinLimiter(zoomOptions, tickOpts.min);
+	tickOpts.max = rangeMaxLimiter(zoomOptions, tickOpts.max);
 }
 
 function zoomScale(scale, zoom, center, zoomOptions) {


### PR DESCRIPTION
Existing error: Logarithmic scale gets cleared out by zooming out.

Error diagnosis: Minimum value of scale was getting a negative value, logarithmic scales are not able to show negative values -> gets cleared out.

Bug fixing: When the scale would get a negative value it will be substituted by 0.

Closes https://github.com/chartjs/chartjs-plugin-zoom/issues/153