### PR TITLE
Store original scale options to resetZoom properly

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -342,7 +342,6 @@ var zoomPlugin = {
 	id: 'zoom',
 
 	afterInit: function(chartInstance) {
-		storeOriginalOptions(chartInstance);
 
 		chartInstance.resetZoom = function() {
 			storeOriginalOptions(chartInstance);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -27,7 +27,11 @@ var defaultOptions = zoomNS.defaults = {
 	}
 };
 // Stores the original options of the scales
-var originalOptions =  {};
+var originalOptions = {};
+
+function storeOriginalOptions(scale) {
+	originalOptions[scale.id] = helpers.clone(scale.options);
+}
 
 function directionEnabled(mode, dir) {
 	if (mode === undefined) {
@@ -271,7 +275,7 @@ function doPan(chartInstance, deltaX, deltaY) {
 		panOptions.speed = helpers.getValueOrDefault(chartInstance.options.pan.speed, defaultOptions.pan.speed);
 
 		helpers.each(chartInstance.scales, function(scale) {
-			if (!originalOptions[id]) {
+			if (!originalOptions[scale.id]) {
 				storeOriginalOptions(scale);
 			}
 			if (scale.isHorizontal() && directionEnabled(panMode, 'x') && deltaX !== 0) {
@@ -313,10 +317,6 @@ function getYAxis(chartInstance) {
 			return scale;
 		}
 	}
-}
-
-function storeOriginalOptions(scale) {
-	originalOptions[scale.id] = helpers.clone(scale.options);
 }
 
 // Store these for later


### PR DESCRIPTION
Fixes #197 

With introducing a new data structure `originalOptions`, the scale options can be stored and recalled to reset the zooming/panning.