### PR TITLE
Ensure pan works when zoom is disabled

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -361,9 +361,6 @@ var zoomPlugin = {
 
 		var options = chartInstance.options;
 		var panThreshold = helpers.getValueOrDefault(options.pan ? options.pan.threshold : undefined, zoomNS.defaults.pan.threshold);
-		if (!options.zoom || !options.zoom.enabled) {
-			return;
-		}
 
 		chartInstance.zoom._mouseDownHandler = function(event) {
 			if (chartInstance.options.zoom.drag) {


### PR DESCRIPTION
Closes https://github.com/chartjs/chartjs-plugin-zoom/issues/132

Also allows you to turn on zoom if it's not when the chart is originally rendered