### PR TITLE
Don't delete dataset._meta

### DIFF
--- a/samples/zoom-time.html
+++ b/samples/zoom-time.html
@@ -85,7 +85,7 @@
 					xAxes: [{
 						type: 'time',
 						time: {
-							format: timeFormat,
+							parser: timeFormat,
 							// round: 'day'
 							tooltipFormat: 'll HH:mm'
 						},

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -345,10 +345,6 @@ var zoomPlugin = {
 				}
 			});
 
-			helpers.each(chartInstance.data.datasets, function(dataset) {
-				dataset._meta = null;
-			});
-
 			chartInstance.update();
 		};
 


### PR DESCRIPTION
Fixes https://github.com/chartjs/chartjs-plugin-zoom/issues/61

I tested this fix manually against `zoom-time.html` 

I'm guessing the reason it works now but the code was originally required is because the code no longer does `JSON.parse(JSON.stringify(scale.options))` and now does `helpers.clone` instead:

https://github.com/chartjs/chartjs-plugin-zoom/blob/f779867fe2dc2aa66bbdc0959df664dda9461b69/src/plugin.js#L329
