### PR TITLE
prevent interventions

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -478,7 +478,9 @@ var zoomPlugin = {
 				doZoom(chartInstance, 1 + speedPercent, 1 + speedPercent, center);
 
 				// Prevent the event from triggering the default behavior (eg. Content scrolling).
-				event.preventDefault();
+				if (event.cancelable) {
+					event.preventDefault();
+				}
 			}
 		};
 
@@ -564,7 +566,7 @@ var zoomPlugin = {
 			});
 
 			chartInstance.$zoom._ghostClickHandler = function(e) {
-				if (panning) {
+				if (panning && e.cancelable) {
 					e.stopImmediatePropagation();
 					e.preventDefault();
 				}


### PR DESCRIPTION
Check if event is cancelable before 'preventDefault' and 'stopImmediatePropagation' calls to prevent following error:
```
[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```

Found the solution at: https://stackoverflow.com/questions/26478267/touch-move-getting-stuck-ignored-attempt-to-cancel-a-touchmove