### PR TITLE
Fix #233: onPan function is called multiple times (and not as stated …

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ plugins: {
 				x: null,
 				y: null
 			},
-			// Function called once panning is completed
+            // Function called while the user is panning
+            // Useful for internal model state update
+            onPan: function({chart}) { console.log(`I'm panning!!!`); }
+            // Function called once panning is completed
 			// Useful for dynamic data loading
-			onPan: function({chart}) { console.log(`I was panned!!!`); }
+            onPanComplete: function({chart}) { console.log(`I was panned!!!`); }
 		},
 
 		// Container for zoom options

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -291,8 +291,8 @@ function doPan(chartInstance, deltaX, deltaY) {
 
 		chartInstance.update(0);
 
-		if (typeof panOptions.onPan === 'function') {
-			panOptions.onPan({chart: chartInstance});
+		if (typeof panOptions.onPanChange === 'function') {
+			panOptions.onPanChange({chart: chartInstance});
 		}
 	}
 }
@@ -558,7 +558,12 @@ var zoomPlugin = {
 				zoomNS.panCumulativeDelta = 0;
 				setTimeout(function() {
 					panning = false;
-				}, 500);
+                }, 500);
+                
+                var panOptions = chartInstance.$zoom._options.pan;
+                if (typeof panOptions.onPan === 'function') {
+                    panOptions.onPan({chart: chartInstance});
+                }
 			});
 
 			chartInstance.$zoom._ghostClickHandler = function(e) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -291,8 +291,8 @@ function doPan(chartInstance, deltaX, deltaY) {
 
 		chartInstance.update(0);
 
-		if (typeof panOptions.onPanChange === 'function') {
-			panOptions.onPanChange({chart: chartInstance});
+		if (typeof panOptions.onPan === 'function') {
+			panOptions.onPan({chart: chartInstance});
 		}
 	}
 }
@@ -561,8 +561,8 @@ var zoomPlugin = {
 				}, 500);
 
 				var panOptions = chartInstance.$zoom._options.pan;
-				if (typeof panOptions.onPan === 'function') {
-					panOptions.onPan({chart: chartInstance});
+				if (typeof panOptions.onPanComplete === 'function') {
+					panOptions.onPanComplete({chart: chartInstance});
 				}
 			});
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -558,12 +558,12 @@ var zoomPlugin = {
 				zoomNS.panCumulativeDelta = 0;
 				setTimeout(function() {
 					panning = false;
-                }, 500);
-                
-                var panOptions = chartInstance.$zoom._options.pan;
-                if (typeof panOptions.onPan === 'function') {
-                    panOptions.onPan({chart: chartInstance});
-                }
+				}, 500);
+
+				var panOptions = chartInstance.$zoom._options.pan;
+				if (typeof panOptions.onPan === 'function') {
+					panOptions.onPan({chart: chartInstance});
+				}
 			});
 
 			chartInstance.$zoom._ghostClickHandler = function(e) {


### PR DESCRIPTION
See also Issue #233 (https://github.com/chartjs/chartjs-plugin-zoom/issues/233).

Currently the documentation ([README.md](https://github.com/chartjs/chartjs-plugin-zoom/blob/master/README.md)) says:

    // Function called once panning is completed
    // Useful for dynamic data loading
    onPan: function({chart}) { console.log(`I was panned!!!`); }

which is not correct. In `src/plugin.js` it can clearly be seen:

    var handlePan = function(e) {
        ...
            doPan(chartInstance, deltaX, deltaY);
        ...
    };

    mc.on('panstart', function(e) {
        ...
        handlePan(e);
    });
    mc.on('panmove', handlePan);
    mc.on('panend', function() {
        ...
    });

    // ...

    function doPan(chartInstance, deltaX, deltaY) {
        ...
    		if (typeof panOptions.onPan === 'function') {
    			panOptions.onPan({chart: chartInstance});
    		}
    	...
    }

That the function is called on `panstart` and `panmove`. For the intended use-case (e.g. loading dynamically data) this is not helpful at all.

Therefore this merge request fixes the issue and adds besides the `onPan` callback also a `onPanChange` callback.