### PR TITLE
Add isModeEnabledFn to zoom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ plugins: {
 			// Eg. 'y' would only allow zooming in the y direction
 			mode: 'xy',
 
+			// Optional function for disabling the enabled mode, given an event.
+			// Allows disabling modes based on other keyboard properties.
+			// Ex. disabling the 'y' direction when a particular key is pressed.
+			// event: nullable DOM event
+			// direction: 'x' or 'y'
+			isModeEnabledOverrideFn: (event, direction) => true,
+
 			rangeMin: {
 				// Format of min zoom range depends on scale type
 				x: null,


### PR DESCRIPTION
## Summary
Add an optional function property, isModeEnabledFn to the zoom
options. This allows disabling modes based on other keyboard
properties.
Ex. disabling the 'y' direction when a particular key is pressed

## Explanation
👋 Sorry I did not add an issue ahead of time for this. We've been using this plugin in our project (it's great!) but there's one feature we needed that wasn't in this library. Please let me know what I should do to get this in the plugin - I'm open to suggestions on everything. The main use-case that we want to preserve is the ability to call a function that is passed in to decide whether to enable or disabling zooming in a particular direction.

