### PR TITLE
Allow using a function for `mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ plugins: {
 
 			// Panning directions. Remove the appropriate direction to disable
 			// Eg. 'y' would only allow panning in the y direction
+			// A function that is called as the user is panning can also be used:
+			//   mode: function({chart, direction}: {chart: ChartJS.Chart, direction: 'x' | 'y'}) {
+			//     return direction === 'y'
+		    //   },
 			mode: 'xy',
 
 			rangeMin: {
@@ -69,6 +73,10 @@ plugins: {
 
 			// Zooming directions. Remove the appropriate direction to disable
 			// Eg. 'y' would only allow zooming in the y direction
+			// A function that is called as the user is panning can also be used:
+			//   mode: function({ chart, direction }: { chart: ChartJS.Chart, direction: 'x' | 'y' }) {
+			//     return direction === 'y'
+		    //   },
 			mode: 'xy',
 
 			rangeMin: {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ plugins: {
 			// A function that is called as the user is panning and returns the
 			// available directions can also be used:
 			//   mode: function({ chart }) {
-			//     return 'xy'
+			//     return 'xy';
 			//   },
 			mode: 'xy',
 
@@ -77,7 +77,7 @@ plugins: {
 			// A function that is called as the user is zooming and returns the
 			// available directions can also be used:
 			//   mode: function({ chart }) {
-			//     return 'xy'
+			//     return 'xy';
 			//   },
 			mode: 'xy',
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ plugins: {
 
 			// Panning directions. Remove the appropriate direction to disable
 			// Eg. 'y' would only allow panning in the y direction
-			// A function that is called as the user is panning can also be used:
-			//   mode: function({chart, direction}: {chart: ChartJS.Chart, direction: 'x' | 'y'}) {
-			//     return direction === 'y'
+			// A function that is called as the user is panning and returns the
+			// available directions can also be used:
+			//   mode: function({ chart }: { chart: ChartJS.Chart }) {
+			//     return 'xy'
 		    //   },
 			mode: 'xy',
 
@@ -73,9 +74,10 @@ plugins: {
 
 			// Zooming directions. Remove the appropriate direction to disable
 			// Eg. 'y' would only allow zooming in the y direction
-			// A function that is called as the user is panning can also be used:
-			//   mode: function({ chart, direction }: { chart: ChartJS.Chart, direction: 'x' | 'y' }) {
-			//     return direction === 'y'
+			// A function that is called as the user is zooming and returns the
+			// available directions can also be used:
+			//   mode: function({ chart }: { chart: ChartJS.Chart }) {
+			//     return 'xy'
 		    //   },
 			mode: 'xy',
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ plugins: {
 			// Eg. 'y' would only allow panning in the y direction
 			// A function that is called as the user is panning and returns the
 			// available directions can also be used:
-			//   mode: function({ chart }: { chart: ChartJS.Chart }) {
+			//   mode: function({ chart }) {
 			//     return 'xy'
-		    //   },
+			//   },
 			mode: 'xy',
 
 			rangeMin: {
@@ -76,9 +76,9 @@ plugins: {
 			// Eg. 'y' would only allow zooming in the y direction
 			// A function that is called as the user is zooming and returns the
 			// available directions can also be used:
-			//   mode: function({ chart }: { chart: ChartJS.Chart }) {
+			//   mode: function({ chart }) {
 			//     return 'xy'
-		    //   },
+			//   },
 			mode: 'xy',
 
 			rangeMin: {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -73,8 +73,10 @@ function storeOriginalOptions(chart) {
 	});
 }
 
-// Mode can be a string ('x', 'y' or 'xy').
-// Direction can be 'x' or 'y'.
+/**
+ * @param {string} mode can be 'x', 'y' or 'xy'
+ * @param {string} dir can be 'x' or 'y'
+ */
 function directionEnabled(mode, dir) {
 	if (mode === undefined) {
 		return true;
@@ -197,7 +199,7 @@ function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes) {
 	if (zoomOptions.enabled) {
 		storeOriginalOptions(chart);
 		// Do the zoom here
-		var zoomMode = zoomOptions.mode === 'function' ? zoomOptions.mode({chart}) : zoomOptions.mode;
+		var zoomMode = typeof zoomOptions.mode === 'function' ? zoomOptions.mode({chart: chart}) : zoomOptions.mode;
 
 		// Which axe should be modified when figers were used.
 		var _whichAxes;
@@ -303,7 +305,7 @@ function doPan(chartInstance, deltaX, deltaY) {
 	storeOriginalOptions(chartInstance);
 	var panOptions = chartInstance.$zoom._options.pan;
 	if (panOptions.enabled) {
-		var panMode = panOptions.mode === 'function' ? panOptions.mode({chart: chartInstance}) : panOptions.mode;
+		var panMode = typeof panOptions.mode === 'function' ? panOptions.mode({chart: chartInstance}) : panOptions.mode;
 
 		helpers.each(chartInstance.scales, function(scale) {
 			if (scale.isHorizontal() && directionEnabled(panMode, 'x') && deltaX !== 0) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -73,11 +73,16 @@ function storeOriginalOptions(chart) {
 	});
 }
 
-function directionEnabled(mode, dir) {
+// Mode can be a string ('x', 'y' or 'xy') or a function that takes the direction and chart instance and returns a
+// boolean.
+// Direction can be 'x' or 'y'.
+function directionEnabled(chartInstance, mode, dir) {
 	if (mode === undefined) {
 		return true;
 	} else if (typeof mode === 'string') {
 		return mode.indexOf(dir) !== -1;
+	} else if (typeof mode === 'function') {
+		return mode({direction: dir, chart: chartInstance});
 	}
 
 	return false;
@@ -199,7 +204,7 @@ function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes) {
 
 		// Which axe should be modified when figers were used.
 		var _whichAxes;
-		if (zoomMode === 'xy' && whichAxes !== undefined) {
+		if (directionEnabled(chart, zoomMode, 'x') && directionEnabled(chart, zoomMode, 'y') && whichAxes !== undefined) {
 			// based on fingers positions
 			_whichAxes = whichAxes;
 		} else {
@@ -208,10 +213,10 @@ function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes) {
 		}
 
 		helpers.each(chart.scales, function(scale) {
-			if (scale.isHorizontal() && directionEnabled(zoomMode, 'x') && directionEnabled(_whichAxes, 'x')) {
+			if (scale.isHorizontal() && directionEnabled(chart, zoomMode, 'x') && directionEnabled(chart, _whichAxes, 'x')) {
 				zoomOptions.scaleAxes = 'x';
 				zoomScale(scale, percentZoomX, focalPoint, zoomOptions);
-			} else if (!scale.isHorizontal() && directionEnabled(zoomMode, 'y') && directionEnabled(_whichAxes, 'y')) {
+			} else if (!scale.isHorizontal() && directionEnabled(chart, zoomMode, 'y') && directionEnabled(chart, _whichAxes, 'y')) {
 				// Do Y zoom
 				zoomOptions.scaleAxes = 'y';
 				zoomScale(scale, percentZoomY, focalPoint, zoomOptions);
@@ -304,10 +309,10 @@ function doPan(chartInstance, deltaX, deltaY) {
 		var panMode = panOptions.mode;
 
 		helpers.each(chartInstance.scales, function(scale) {
-			if (scale.isHorizontal() && directionEnabled(panMode, 'x') && deltaX !== 0) {
+			if (scale.isHorizontal() && directionEnabled(chartInstance, panMode, 'x') && deltaX !== 0) {
 				panOptions.scaleAxes = 'x';
 				panScale(scale, deltaX, panOptions);
-			} else if (!scale.isHorizontal() && directionEnabled(panMode, 'y') && deltaY !== 0) {
+			} else if (!scale.isHorizontal() && directionEnabled(chartInstance, panMode, 'y') && deltaY !== 0) {
 				panOptions.scaleAxes = 'y';
 				panScale(scale, deltaY, panOptions);
 			}
@@ -462,11 +467,11 @@ var zoomPlugin = {
 
 			var zoomOptions = chartInstance.$zoom._options.zoom;
 			var chartDistanceX = chartArea.right - chartArea.left;
-			var xEnabled = directionEnabled(zoomOptions.mode, 'x');
+			var xEnabled = directionEnabled(chartInstance, zoomOptions.mode, 'x');
 			var zoomX = xEnabled && dragDistanceX ? 1 + ((chartDistanceX - dragDistanceX) / chartDistanceX) : 1;
 
 			var chartDistanceY = chartArea.bottom - chartArea.top;
-			var yEnabled = directionEnabled(zoomOptions.mode, 'y');
+			var yEnabled = directionEnabled(chartInstance, zoomOptions.mode, 'y');
 			var zoomY = yEnabled && dragDistanceY ? 1 + ((chartDistanceY - dragDistanceY) / chartDistanceY) : 1;
 
 			doZoom(chartInstance, zoomX, zoomY, {
@@ -621,13 +626,13 @@ var zoomPlugin = {
 			var startY = yAxis.top;
 			var endY = yAxis.bottom;
 
-			if (directionEnabled(chartInstance.$zoom._options.zoom.mode, 'x')) {
+			if (directionEnabled(chartInstance, chartInstance.$zoom._options.zoom.mode, 'x')) {
 				var offsetX = beginPoint.target.getBoundingClientRect().left;
 				startX = Math.min(beginPoint.clientX, endPoint.clientX) - offsetX;
 				endX = Math.max(beginPoint.clientX, endPoint.clientX) - offsetX;
 			}
 
-			if (directionEnabled(chartInstance.$zoom._options.zoom.mode, 'y')) {
+			if (directionEnabled(chartInstance, chartInstance.$zoom._options.zoom.mode, 'y')) {
 				var offsetY = beginPoint.target.getBoundingClientRect().top;
 				startY = Math.min(beginPoint.clientY, endPoint.clientY) - offsetY;
 				endY = Math.max(beginPoint.clientY, endPoint.clientY) - offsetY;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -73,8 +73,8 @@ function storeOriginalOptions(chart) {
 	});
 }
 
-// Mode can be a string ('x', 'y' or 'xy') or a function that takes the direction and chart instance and returns a
-// boolean.
+// Mode can be a string ('x', 'y' or 'xy') or a function that takes a chart instance and returns a direction string
+// ('x', 'y', or 'xy').
 // Direction can be 'x' or 'y'.
 function directionEnabled(chartInstance, mode, dir) {
 	if (mode === undefined) {
@@ -82,7 +82,7 @@ function directionEnabled(chartInstance, mode, dir) {
 	} else if (typeof mode === 'string') {
 		return mode.indexOf(dir) !== -1;
 	} else if (typeof mode === 'function') {
-		return mode({direction: dir, chart: chartInstance});
+		return mode({chart: chartInstance}).indexOf(dir) !== -1;
 	}
 
 	return false;


### PR DESCRIPTION
Allow using a function for `mode` that takes the chart and returns the directions available to scroll. This allows disabling a scrollable x or y direction based on application state instead of a static option.

Fixes #257. Feedback taken from #246 