### PR TITLE
Fixing README to make it directly usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ plugins: {
 			speed: 0.1,
 
 			// Function called while the user is zooming
-			onZoom: function({chart}) { console.log(`I'm zooming!!!`); }
+			onZoom: function({chart}) { console.log(`I'm zooming!!!`); },
 			// Function called once zooming is completed
 			onZoomComplete: function({chart}) { console.log(`I was zoomed!!!`); }
 		}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ plugins: {
 			},
 
 			// Function called while the user is panning
-			onPan: function({chart}) { console.log(`I'm panning!!!`); }
+			onPan: function({chart}) { console.log(`I'm panning!!!`); },
 			// Function called once panning is completed
 			onPanComplete: function({chart}) { console.log(`I was panned!!!`); }
 		},


### PR DESCRIPTION
Example is missing 2 commas