### PR TITLE
Fix #265 - trigger onZoomComplete() on pinch

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -547,6 +547,11 @@ var zoomPlugin = {
 
 				doZoom(chartInstance, diff, diff, center, xy);
 
+				var zoomOptions = chartInstance.$zoom._options.zoom;
+				if (typeof zoomOptions.onZoomComplete === 'function') {
+					zoomOptions.onZoomComplete({chart: chartInstance});
+				}
+
 				// Keep track of overall scale
 				currentPinchScaling = e.scale;
 			};


### PR DESCRIPTION
This is an attempt to fix #265 by adding a call to `onZoomComplete()` in `handlePinch()` function.

Quickly tested on Android emulator.