### PR TITLE
Fix for chartjs v3.0 deprecated functions

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -416,7 +416,7 @@ var zoomPlugin = {
 		chartInstance.$zoom = {
 			_originalOptions: {}
 		};
-		var node = chartInstance.$zoom._node = chartInstance.chart.ctx.canvas;
+		var node = chartInstance.$zoom._node = chartInstance.ctx.canvas;
 		resolveOptions(chartInstance, pluginOptions);
 
 		var options = chartInstance.$zoom._options;
@@ -617,7 +617,7 @@ var zoomPlugin = {
 	},
 
 	beforeDatasetsDraw: function(chartInstance) {
-		var ctx = chartInstance.chart.ctx;
+		var ctx = chartInstance.ctx;
 
 		if (chartInstance.$zoom._dragZoomEnd) {
 			var xAxis = getXAxis(chartInstance);


### PR DESCRIPTION
This corrects two functions in chartjs-plugin-zoom that are using deprecated calls which are removed in git master for chartjs v3.0.

This is my first pull request... please excuse any errors.