### PR TITLE
Fix #280 - Deprecation warning with Chart JS 2.9.1

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -169,8 +169,12 @@ function zoomTimeScale(scale, zoom, center, zoomOptions) {
 
 	var options = scale.options;
 	if (options.time) {
-		if (options.time.min) options.time.min = options.ticks.min;
-		if (options.time.max) options.time.max = options.ticks.max;
+		if (options.time.min) {
+			options.time.min = options.ticks.min;
+		}
+		if (options.time.max) {
+			options.time.max = options.ticks.max;
+		}
 	}
 }
 
@@ -294,8 +298,12 @@ function panTimeScale(scale, delta, panOptions) {
 
 	var options = scale.options;
 	if (options.time) {
-		if (options.time.min) options.time.min = options.ticks.min;
-		if (options.time.max) options.time.max = options.ticks.max;
+		if (options.time.min) {
+			options.time.min = options.ticks.min;
+		}
+		if (options.time.max) {
+			options.time.max = options.ticks.max;
+		}
 	}
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -416,7 +416,7 @@ var zoomPlugin = {
 		chartInstance.$zoom = {
 			_originalOptions: {}
 		};
-		var node = chartInstance.$zoom._node = chartInstance.chart.ctx.canvas;
+		var node = chartInstance.$zoom._node = chartInstance.ctx.canvas;
 		resolveOptions(chartInstance, pluginOptions);
 
 		var options = chartInstance.$zoom._options;
@@ -617,7 +617,7 @@ var zoomPlugin = {
 	},
 
 	beforeDatasetsDraw: function(chartInstance) {
-		var ctx = chartInstance.chart.ctx;
+		var ctx = chartInstance.ctx;
 
 		if (chartInstance.$zoom._dragZoomEnd) {
 			var xAxis = getXAxis(chartInstance);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -167,8 +167,11 @@ function zoomNumericalScale(scale, zoom, center, zoomOptions) {
 function zoomTimeScale(scale, zoom, center, zoomOptions) {
 	zoomNumericalScale(scale, zoom, center, zoomOptions);
 
-	scale.options.time.min = scale.options.ticks.min;
-	scale.options.time.max = scale.options.ticks.max;
+	var options = scale.options;
+	if (options.time) {
+		if (options.time.min) options.time.min = options.ticks.min;
+		if (options.time.max) options.time.max = options.ticks.max;
+	}
 }
 
 function zoomScale(scale, zoom, center, zoomOptions) {
@@ -290,8 +293,10 @@ function panTimeScale(scale, delta, panOptions) {
 	panNumericalScale(scale, delta, panOptions);
 
 	var options = scale.options;
-	options.time.min = options.ticks.min;
-	options.time.max = options.ticks.max;
+	if (options.time) {
+		if (options.time.min) options.time.min = options.ticks.min;
+		if (options.time.max) options.time.max = options.ticks.max;
+	}
 }
 
 function panScale(scale, delta, panOptions) {


### PR DESCRIPTION
Fix for Issue #280 by only using the time options if they are configured by the chart. This will enable backward compatibility while resolving the deprecation warnings for time axis charts with Chart JS 2.9.1.

Note: If the code calling the chart is still using time.min or time.max with Chart JS 2.9.1, it will continue to log deprecation warnings. This will ensure the chart still works.