### PR TITLE
Unnecessary chart update?

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -430,7 +430,6 @@ var zoomPlugin = {
 		chartInstance.$zoom._mouseMoveHandler = function(event) {
 			if (chartInstance.$zoom._dragZoomStart) {
 				chartInstance.$zoom._dragZoomEnd = event;
-				chartInstance.update(0);
 			}
 		};
 


### PR DESCRIPTION
Not sure if I'm missing something, but this seems to cause an unnecessary amount of chart updates during mouse drag. Seems like removing it doesn't cause any issues down the line.

The performance gain is very noticable in big datasets.