### PR TITLE
checking the existance of zoom instead of pan option

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -32,7 +32,7 @@ function resolveOptions(chart, options) {
 	if (typeof chart.options.pan !== 'undefined') {
 		deprecatedOptions.pan = chart.options.pan;
 	}
-	if (typeof chart.options.pan !== 'undefined') {
+	if (typeof chart.options.zoom !== 'undefined') {
 		deprecatedOptions.zoom = chart.options.zoom;
 	}
 	var props = chart.$zoom;


### PR DESCRIPTION
I believe this mistake doesn't generate a bug, because `typeof chart.options.pan !== 'undefined'` is always true due to `chart.options.pan` has a default value. But for having a clear code i think we should correct it.