### PR TITLE
resetZoom() duration parameter to override animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-plugin-zoom",
-  "version": "0.7.0",
+  "version": "0.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chartjs-plugin-zoom",
   "description": "Plugin that enables zoom and pan functionality in Chart.js charts.",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "license": "MIT",
   "jsdelivr": "dist/chartjs-plugin-zoom.min.js",
   "unpkg": "dist/chartjs-plugin-zoom.min.js",


### PR DESCRIPTION
I would like to add a feature or option for the resetZoom, some users dont want their chart to animate (esp. real time monitoring applications), but still want to do zoom animations. as i can see we can pass in a value at the update() function to override global animation.

```
chartInstance.resetZoom = function (duration) {
	storeOriginalOptions(chartInstance);
	var originalOptions = chartInstance.$zoom._originalOptions;
	helpers.each(chartInstance.scales, function (scale) {

		var timeOptions = scale.options.time;
		var tickOptions = scale.options.ticks;

		if (originalOptions[scale.id]) {

			if (timeOptions) {
				timeOptions.min = originalOptions[scale.id].time.min;
				timeOptions.max = originalOptions[scale.id].time.max;
			}

			if (tickOptions) {
				tickOptions.min = originalOptions[scale.id].ticks.min;
				tickOptions.max = originalOptions[scale.id].ticks.max;
			}
		} else {

			if (timeOptions) {
				delete timeOptions.min;
				delete timeOptions.max;
			}

			if (tickOptions) {
				delete tickOptions.min;
				delete tickOptions.max;
			}
		}


	});

	chartInstance.update(duration);
};
```