### PR TITLE
added allowZoom pre-condition to filter out unnecessary zoom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,25 @@ plugins: {
 			 */
 			/**
 			 * This function may be used to filter unnessecary zoom events. Returns true to allow zooming, false to prevent.
+			 * (default ticks.min and ticks.max will also limit zoom range)
 			 * @param {Chart} chart - Chart instance.
 			 * @param {Scale} scale - Scale/Axis being zoomed (x/y, method will be called for each axis)
 			 * @param {ChartOptions} options - Original chart options before any zoom values applied.
 			 * @param {PendingScaleChanges} changes - Changes that will be applied to chart options if method returns true.
-			allowZoom: function(chart, scale, options, changes)
+			allowZoom: function(chart, scale, options, changes) {
+			  if (scale.id === 'x-axis-0') {
+				const millisecondsInSecond = 1000;
+				const secondsInViewBefore = (beforeZoom.ticks.max - beforeZoom.ticks.min) / millisecondsInSecond;
+				const secondsInViewAfter = (changes.ticks.max - changes.ticks.min) / millisecondsInSecond;
+				
+				// Allow to zoom until there will be 60 seconds in view and allow to zoom out.
+				// (default ticks.min and ticks.max will also limit zoom range)
+				if (secondsInViewAfter < 60 && secondsInViewAfter <= secondsInViewBefore) {
+					return false;
+				}
+			  }
+			  return true;
+			}
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,25 @@ plugins: {
 			// Function called while the user is zooming
 			onZoom: function({chart}) { console.log(`I'm zooming!!!`); },
 			// Function called once zooming is completed
-			onZoomComplete: function({chart}) { console.log(`I was zoomed!!!`); }
+			onZoomComplete: function({chart}) { console.log(`I was zoomed!!!`); },
+			
+			/**
+			 * @typedef {Object} MinMaxValue
+			 * @property {number} min - Min value
+			 * @property {number} max - Max value
+			 */
+			/**
+			 * @typedef {Object} PendingScaleChanges - Represents min/max value updates for ticks and time options.
+			 * @property {MinMaxValue} ticks - new options.ticks values
+			 * @property {MinMaxValue} time - new options.time values (may be undefined)
+			 */
+			/**
+			 * This function may be used to filter unnessecary zoom events. Returns true to allow zooming, false to prevent.
+			 * @param {Chart} chart - Chart instance.
+			 * @param {Scale} scale - Scale/Axis being zoomed (x/y, method will be called for each axis)
+			 * @param {ChartOptions} options - Original chart options before any zoom values applied.
+			 * @param {PendingScaleChanges} changes - Changes that will be applied to chart options if method returns true.
+			allowZoom: function(chart, scale, options, changes)
 		}
 	}
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -153,7 +153,7 @@ function zoomCategoryScale(scale, zoom, center, zoomOptions) {
 				min: rangeMinLimiter(zoomOptions, labels[minIndex]),
 				max: rangeMaxLimiter(zoomOptions, labels[maxIndex])
 			}
-		}
+		};
 	}
 
 	return undefined;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -149,10 +149,10 @@ function zoomCategoryScale(scale, zoom, center, zoomOptions) {
 		}
 
 		return {
-		    ticks: {
-		        min: rangeMinLimiter(zoomOptions, labels[minIndex]),
-		        max: rangeMaxLimiter(zoomOptions, labels[maxIndex])
-		    }
+			ticks: {
+				min: rangeMinLimiter(zoomOptions, labels[minIndex]),
+				max: rangeMaxLimiter(zoomOptions, labels[maxIndex])
+			}
 		}
 	}
 
@@ -256,30 +256,30 @@ function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, animat
 
 		helpers.each(chart.scales, function(scale) {
 			var originalOptions = helpers.clone(scale.options);
-		
+
 			function applyZoomScale(axis, zoomPercent) {
 				zoomOptions.scaleAxes = axis;
 				var changes = zoomScale(scale, zoomPercent, focalPoint, zoomOptions);
 				var allowZoomDefined = zoomOptions.allowZoom && typeof zoomOptions.allowZoom === 'function';
-		
+
 				if (changes && (!allowZoomDefined || zoomOptions.allowZoom(chart, scale, originalOptions, changes))) {
 					scale.options.ticks.min = changes.ticks.min;
 					scale.options.ticks.max = changes.ticks.max;
-		
+
 					if (changes.time) {
 						scale.options.time.min = changes.time.min;
 						scale.options.time.max = changes.time.max;
 					}
 				}
 			}
-		
+
 			if (scale.isHorizontal() && directionEnabled(zoomMode, 'x', chart) && directionEnabled(_whichAxes, 'x', chart)) {
 				applyZoomScale('x', percentZoomX);
 			} else if (!scale.isHorizontal() && directionEnabled(zoomMode, 'y', chart) && directionEnabled(_whichAxes, 'y', chart)) {
 				applyZoomScale('y', percentZoomY);
 			}
 		});
-		
+
 		if (animationDuration) {
 			chart.update({
 				duration: animationDuration,


### PR DESCRIPTION
Extended zoom plugin options with parameter `options.plugins.zoom.allowZoom`. It is function with signature of 
```
function allowZoom(
  chart: Chart, 
  scale: ChartElement, 
  originalOptions: ScalesOptions, 
  changes: ScalesOptionsPendingChanges
): boolean
```
May be used to prevent unnecessary zooming operations (e.g. chart is zoomed too near).

If function is defined and returns false, chart scale options will be restored as before calculating new time/ticks value (before calling chart.update).

p.s. Added example of usage to README