### PR TITLE
feature: implement `threshold` for zoom operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ plugins: {
 			// On category scale, minimal zoom level before actually applying zoom
 			sensitivity: 3,
 
+			// Minimum mouse-movement delta before zoom is triggered, default `0`
+			threshold: 0,
+
 			// Function called while the user is zooming
 			onZoom: function({chart}) { console.log(`I'm zooming!!!`); },
 			// Function called once zooming is completed

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,6 +23,7 @@ Chart.Zoom.defaults = Chart.defaults.global.plugins.zoom = {
 		enabled: false,
 		mode: 'xy',
 		sensitivity: 3,
+		threshold: 0,
 		speed: 0.1
 	}
 };
@@ -482,13 +483,14 @@ var zoomPlugin = {
 			chartInstance.$zoom._dragZoomStart = null;
 			chartInstance.$zoom._dragZoomEnd = null;
 
-			if (dragDistanceX <= 0 && dragDistanceY <= 0) {
+			var zoomOptions = chartInstance.$zoom._options.zoom;
+
+			if (dragDistanceX <= zoomOptions.threshold && dragDistanceY <= zoomOptions.threshold) {
 				return;
 			}
 
 			var chartArea = chartInstance.chartArea;
 
-			var zoomOptions = chartInstance.$zoom._options.zoom;
 			var chartDistanceX = chartArea.right - chartArea.left;
 			var xEnabled = directionEnabled(zoomOptions.mode, 'x', chartInstance);
 			var zoomX = xEnabled && dragDistanceX ? 1 + ((chartDistanceX - dragDistanceX) / chartDistanceX) : 1;

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -12,6 +12,7 @@ describe('defaults', function() {
 			enabled: false,
 			mode: 'xy',
 			sensitivity: 3,
+			threshold: 0,
 			speed: 0.1
 		}
 	};


### PR DESCRIPTION
WHAT:
Implement a `threshold` option for Zoom.

WHY:
Certain scenarios trigger unwanted zoom operations - not necessarily a bug in the zoom code, but one that demands a bit more buffer before committing to a zoom.  I.e., if the chart is using CSS to fit a certain shape using percentages for width or height, a click (mousedown -> mouseup) could be misconstrued as a zoom operation.

HOW:
add an option, defaulting to the standard OOTB behavior.