### PR TITLE
fix bug introduced in #338 (If-statement not reversed)

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -516,7 +516,7 @@ var zoomPlugin = {
 
 			// Firefox always fires the wheel event twice:
 			// First without the delta and right after that once with the delta properties.
-			if (typeof event.deltaY !== 'undefined') {
+			if (typeof event.deltaY === 'undefined') {
 				return;
 			}
 


### PR DESCRIPTION
In the previous change I made to the repository I forgot to change the if statement after applying the proposed changes.

In the pull request I included a new if statement which I was asked to reverse. While I did change the code which was executed, I did not change the if-Statement.

I am truly sorry for this mistake.

Previous PR (#338)
Comment by @benmccann proposing the changes (https://github.com/chartjs/chartjs-plugin-zoom/pull/338#issuecomment-609907513)