### PR TITLE
Keep aspect ratio on zoom with minmax range

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -163,8 +163,20 @@ function zoomNumericalScale(scale, zoom, center, zoomOptions) {
 	var minDelta = newDiff * minPercent;
 	var maxDelta = newDiff * maxPercent;
 
-	scale.options.ticks.min = rangeMinLimiter(zoomOptions, scale.min + minDelta);
-	scale.options.ticks.max = rangeMaxLimiter(zoomOptions, scale.max - maxDelta);
+	var supposedMin = scale.min + minDelta;
+	var supposedMax = scale.max - maxDelta;
+
+	var min = rangeMinLimiter(zoomOptions, supposedMin);
+	var max = rangeMaxLimiter(zoomOptions, supposedMax);
+
+	if (min > supposedMin) {
+		max = rangeMaxLimiter(zoomOptions, supposedMax + (min - supposedMin));
+	}
+	if (max < supposedMax) {
+		min = rangeMinLimiter(zoomOptions, supposedMin - (supposedMax - max));
+	}
+	scale.options.ticks.min = min;
+	scale.options.ticks.max = max;
 }
 
 function zoomTimeScale(scale, zoom, center, zoomOptions) {


### PR DESCRIPTION
I think that this issue is exactly about the problem I have faced with: https://github.com/chartjs/chartjs-plugin-zoom/issues/115

Charts that has min max ranges for zoom works with distortion when chart viewport could zoom out only into one direction, not in both directions due to range limitation. I have worked only with numeric charts. Maybe for other types such distortion is ok. 