### PR TITLE
Expose changeZoom and changePan APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ plugins: {
 
 ## API
 
+### chart.changePan(deltaX, deltaY)
+
+Programmatically change the pan. Pass differences for x and y axes.
+
+### chart.changeZoom(percentZoomX, percentZoomY)
+
+Programmatically change the zoom. Pass zoom percentages for x and/or y axes.
+
 ### chart.resetZoom()
 
 Programmatically resets the zoom to the default state. See [samples/zoom-time.html](samples/zoom-time.html) for an example.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -430,6 +430,13 @@ var zoomPlugin = {
 			chartInstance.update();
 		};
 
+        chartInstance.changeZoom = function (percentZoomX, percentZoomY) {
+            doZoom(chartInstance, percentZoomX, percentZoomY, undefined, undefined, zoomOptions.drag.animationDuration);
+        };
+
+        chartInstance.changePan = function (deltaX, deltaY) {
+            doPan(chartInstance, deltaX, deltaY);
+        };
 	},
 
 	beforeUpdate: function(chart, options) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -431,7 +431,7 @@ var zoomPlugin = {
 		};
 
         chartInstance.changeZoom = function (percentZoomX, percentZoomY) {
-            doZoom(chartInstance, percentZoomX, percentZoomY, undefined, undefined, zoomOptions.drag.animationDuration);
+            doZoom(chartInstance, percentZoomX, percentZoomY);
         };
 
         chartInstance.changePan = function (deltaX, deltaY) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -430,13 +430,13 @@ var zoomPlugin = {
 			chartInstance.update();
 		};
 
-        chartInstance.changeZoom = function (percentZoomX, percentZoomY) {
-            doZoom(chartInstance, percentZoomX, percentZoomY);
-        };
+		chartInstance.changeZoom = function(percentZoomX, percentZoomY) {
+			doZoom(chartInstance, percentZoomX, percentZoomY);
+		};
 
-        chartInstance.changePan = function (deltaX, deltaY) {
-            doPan(chartInstance, deltaX, deltaY);
-        };
+		chartInstance.changePan = function(deltaX, deltaY) {
+			doPan(chartInstance, deltaX, deltaY);
+		};
 	},
 
 	beforeUpdate: function(chart, options) {


### PR DESCRIPTION
We have a way to `resetZoom` but we dont have a way to change the zoom and pan. This PR exposes `doPan` and `doZoom` functions.

Sample usecase: https://codepen.io/elizzk/pen/OJMZMEm