### PR TITLE
Add ctrlKeyWheelHorizontal and shiftKeyWheelVertical to zoom options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ plugins: {
 			//   },
 			mode: 'xy',
 
+			// Only zoom horizontally on ctrl+mouse-wheel
+			// (helps when pan.enabled is true and zoom.drag is false)
+			ctrlKeyWheelHorizontal: false,
+
+			// Only zoom vertically on shift+mouse-wheel
+			// (helps when pan.enabled is true and zoom.drag is false)
+			shiftKeyWheelVertical: false,
+
 			rangeMin: {
 				// Format of min zoom range depends on scale type
 				x: null,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,7 +23,9 @@ Chart.Zoom.defaults = Chart.defaults.global.plugins.zoom = {
 		enabled: false,
 		mode: 'xy',
 		sensitivity: 3,
-		speed: 0.1
+		speed: 0.1,
+		ctrlKeyWheelHorizontal: false,
+		shiftKeyWheelVertical: false
 	}
 };
 
@@ -536,7 +538,19 @@ var zoomPlugin = {
 			if (event.deltaY >= 0) {
 				speedPercent = -speedPercent;
 			}
-			doZoom(chartInstance, 1 + speedPercent, 1 + speedPercent, center);
+
+			var xy = 'xy';      // default
+
+			if (options.zoom.ctrlKeyWheelHorizontal && event.ctrlKey) {
+				// Only zoom horizontally
+				xy = 'x'; // x axis
+			}
+			if (options.zoom.shiftKeyWheelVertical && event.shiftKey) {
+				// Only zoom vertically
+				xy = 'y'; // y axis
+			}
+
+			doZoom(chartInstance, 1 + speedPercent, 1 + speedPercent, center, xy);
 
 			clearTimeout(_scrollTimeout);
 			_scrollTimeout = setTimeout(function() {

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -12,7 +12,9 @@ describe('defaults', function() {
 			enabled: false,
 			mode: 'xy',
 			sensitivity: 3,
-			speed: 0.1
+			speed: 0.1,
+			ctrlKeyWheelHorizontal: false,
+			shiftKeyWheelVertical: false
 		}
 	};
 


### PR DESCRIPTION
When `pan.enabled` is true and `zoom.drag` is false, the graph works nicely on mobile (pinch allows individual or both axis control), but there is no individual axis zoom control on desktop, only proportional zoom at the cursor location.

Enabling one or both of these options allows extending the desktop control for individual axis zoom.