### PR TITLE
Zoom using zoomPercent

### DIFF
--- a/samples/zoom-large-dataset.html
+++ b/samples/zoom-large-dataset.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html>
+
+<head>
+	<title>Bar Chart Zoom - Large dataset</title>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.1"></script>
+	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
+
+	<style>
+	canvas {
+		-moz-user-select: none;
+		-webkit-user-select: none;
+		-ms-user-select: none;
+	}
+	</style>
+</head>
+
+<body>
+	<div id="container" style="width: 75%;">
+		<canvas id="canvas"></canvas>
+	</div>
+
+	<script>
+		var randomScalingFactor = function() {
+			return (Math.random() > 0.5 ? 1.0 : -1.0) * Math.round(Math.random() * 100);
+		};
+
+		const labels = [];
+		const data = [];
+		const dataCount = 1000;
+		for (let i = 0; i < dataCount; i++) {
+			data.push(randomScalingFactor());
+			labels.push(i);
+		}
+
+		var barChartData = {
+			labels: labels,
+			datasets: [{
+				label: 'Dataset 1',
+				backgroundColor: 'rgba(220,220,220,0.5)',
+				data: data
+			}]
+		};
+
+		window.onload = function() {
+			var ctx = document.getElementById('canvas').getContext('2d');
+			window.myBar = new window.Chart(ctx, {
+				type: 'bar',
+				data: barChartData,
+				options: {
+					// Elements options apply to all of the options unless overridden in a dataset
+					// In this case, we are setting the border of each bar to be 2px wide and green
+					elements: {
+						rectangle: {
+							borderWidth: 2,
+							borderColor: 'rgb(0, 255, 0)',
+							borderSkipped: 'bottom'
+						}
+					},
+					responsive: true,
+					legend: {
+						position: 'top',
+					},
+					title: {
+						display: true,
+						text: 'Chart.js Bar Chart'
+					},
+					plugins: {
+						zoom: {
+							zoom: {
+								enabled: true,
+								mode: 'x',
+								sensitivity: 0,
+								speed: 0.1
+							}
+						}
+					}
+				}
+			});
+		};
+	</script>
+</body>
+
+</html>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -120,30 +120,36 @@ function zoomCategoryScale(scale, zoom, center, zoomOptions) {
 	var sensitivity = zoomOptions.sensitivity;
 	var chartCenter = scale.isHorizontal() ? scale.left + (scale.width / 2) : scale.top + (scale.height / 2);
 	var centerPointer = scale.isHorizontal() ? center.x : center.y;
+	var range = maxIndex - minIndex;
+	var absoluteZoom = Math.abs(1 - zoom);
 
 	zoomNS.zoomCumulativeDelta = zoom > 1 ? zoomNS.zoomCumulativeDelta + 1 : zoomNS.zoomCumulativeDelta - 1;
 
 	if (Math.abs(zoomNS.zoomCumulativeDelta) > sensitivity) {
 		if (zoomNS.zoomCumulativeDelta < 0) {
+			// Zoom out
 			if (centerPointer >= chartCenter) {
 				if (minIndex <= 0) {
-					maxIndex = Math.min(lastLabelIndex, maxIndex + 1);
+					// We've already zoomed all the way out to the right
+					maxIndex = Math.min(lastLabelIndex, Math.floor(maxIndex + range * absoluteZoom));
 				} else {
-					minIndex = Math.max(0, minIndex - 1);
+					minIndex = Math.max(0, Math.floor(minIndex - range * absoluteZoom));
 				}
 			} else if (centerPointer < chartCenter) {
 				if (maxIndex >= lastLabelIndex) {
-					minIndex = Math.max(0, minIndex - 1);
+					minIndex = Math.max(0, Math.floor(minIndex - range * absoluteZoom));
 				} else {
-					maxIndex = Math.min(lastLabelIndex, maxIndex + 1);
+					// We've already zoomed all the way out to the left
+					maxIndex = Math.min(lastLabelIndex, Math.floor(maxIndex + range * absoluteZoom));
 				}
 			}
 			zoomNS.zoomCumulativeDelta = 0;
 		} else if (zoomNS.zoomCumulativeDelta > 0) {
+			// Zoom in
 			if (centerPointer >= chartCenter) {
-				minIndex = minIndex < maxIndex ? minIndex = Math.min(maxIndex, minIndex + 1) : minIndex;
+				minIndex = minIndex < maxIndex ? Math.min(maxIndex, Math.floor(minIndex + range * absoluteZoom)) : minIndex;
 			} else if (centerPointer < chartCenter) {
-				maxIndex = maxIndex > minIndex ? maxIndex = Math.max(minIndex, maxIndex - 1) : maxIndex;
+				maxIndex = maxIndex > minIndex ? Math.max(minIndex, Math.floor(maxIndex - range * absoluteZoom)) : maxIndex;
 			}
 			zoomNS.zoomCumulativeDelta = 0;
 		}
@@ -537,6 +543,7 @@ var zoomPlugin = {
 				speedPercent = -speedPercent;
 			}
 			doZoom(chartInstance, 1 + speedPercent, 1 + speedPercent, center);
+			// doZoom(chartInstance, speedPercent, speedPercent, center);
 
 			clearTimeout(_scrollTimeout);
 			_scrollTimeout = setTimeout(function() {


### PR DESCRIPTION
Solves: https://github.com/chartjs/chartjs-plugin-zoom/issues/379

So, when using e.g. 1000 data-points, the zoom is slow in ticks of 1. It seems the indices were only changed in ticks of 1, rather than ticks of the percentage of the current-range.
This PR uses the speed property to set the percentage of the current range to be zoomed, e.g. with 1000 data points currently in view, a speed of 0.1 means we zoom 10% in on that range.

Next up should be to zoom at centerPointer, rather than either right or left.