### PR TITLE
Added optional modifier keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ plugins: {
 			onPanComplete: function({chart}) { console.log(`I was panned!!!`); },
 			// Function called when pan fails because modifier key was not detected.
 			// event is the a hammer event that failed - see https://hammerjs.github.io/api#event-object
-			onModifierKeyFailed: function({chart, event}) { console.log(`I didn't start panning!`); }
+			onPanRejected: function({chart, event}) { console.log(`I didn't start panning!`); }
 		},
 
 		// Container for zoom options
@@ -119,7 +119,7 @@ plugins: {
 			// Function called once zooming is completed
 			onZoomComplete: function({chart}) { console.log(`I was zoomed!!!`); },
 			// Function called when wheel input occurs without modifier key
-			onWheelModifierFailed: function({chart, event}) { console.log(`I didn't start zooming!`); }
+			onZoomRejected: function({chart, event}) { console.log(`I didn't start zooming!`); }
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ plugins: {
 			// Function called while the user is panning
 			onPan: function({chart}) { console.log(`I'm panning!!!`); },
 			// Function called once panning is completed
-			onPanComplete: function({chart}) { console.log(`I was panned!!!`); }
+			onPanComplete: function({chart}) { console.log(`I was panned!!!`); },
+			// Function called when pan fails because modifier key was not detected.
+			// event is the a hammer event that failed - see https://hammerjs.github.io/api#event-object
+			onModifierKeyFailed: function({chart, event}) { console.log(`I didn't start panning!`); }
 		},
 
 		// Container for zoom options
@@ -114,7 +117,9 @@ plugins: {
 			// Function called while the user is zooming
 			onZoom: function({chart}) { console.log(`I'm zooming!!!`); },
 			// Function called once zooming is completed
-			onZoomComplete: function({chart}) { console.log(`I was zoomed!!!`); }
+			onZoomComplete: function({chart}) { console.log(`I was zoomed!!!`); },
+			// Function called when wheel input occurs without modifier key
+			onWheelModifierFailed: function({chart, event}) { console.log(`I didn't start zooming!`); }
 		}
 	}
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -413,8 +413,8 @@ var zoomPlugin = {
       if (zoomOptions
           && zoomOptions.wheelModifierKey
           && !event[zoomOptions.wheelModifierKey + 'Key']) {
-        if (typeof zoomOptions.onWheelModifierKeyFailed === 'function') {
-          zoomOptions.onWheelModifierKeyFailed({
+        if (typeof zoomOptions.onzoomRejected === 'function') {
+          zoomOptions.onzoomRejected({
             chart: chartInstance,
             event: event
           });
@@ -469,8 +469,8 @@ var zoomPlugin = {
         const requireModifier = panOptions.modifierKey
           && (event.pointerType === 'mouse');
         if (requireModifier && !event.srcEvent[panOptions.modifierKey + 'Key']) {
-          if (typeof panOptions.onModifierKeyFailed === 'function') {
-            panOptions.onModifierKeyFailed({
+          if (typeof panOptions.onPanRejected === 'function') {
+            panOptions.onPanRejected({
               chart: chartInstance,
               event: event
             });

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -6,13 +6,15 @@ describe('defaults', function() {
       enabled: false,
       mode: 'xy',
       speed: 20,
-      threshold: 10
+      threshold: 10,
+      modifierKey: null,
     },
     zoom: {
       enabled: false,
       mode: 'xy',
       sensitivity: 3,
-      speed: 0.1
+      speed: 0.1,
+      wheelModifierKey: null
     }
   };
 


### PR DESCRIPTION
Often the chart captures scroll events in an undesired way, so this PR makes it possible to set an optional `wheelModifierKey` that must be pressed to activate mouse wheel zoom.

A `modifierKey` can also be set for pan. By default this is only checked when the input comes via mouse, but can be set for touch and other inputs with `requireModifierNonMouse: true`

`zoom.onWheelModifierKeyFailed` is fired when a zoom does not occur because the modifier key is not present (e.g. to allow the consumer to display "Press ctrl to zoom"). A similar `pan.onModifierKeyFailed` is also available.

Although not necessarily the requested fix, it will help with the following issues:
#377, #370, #335, #308 (Actually I see the collaborators offer to accept PRs on this issue there). Not looking any further...

Relationship to other pull requests:
Might be incompatible with #380.
A more flexible version of #368 
