### PR TITLE
Feature: Zoom each scale separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ plugins: {
    //   },
    mode: 'xy',
 
+   // Which of the enabled panning directions should only be available
+   // when the mouse cursor is over one of scale.
+   overScaleMode: 'xy',
+
    rangeMin: {
     // Format of min pan range depends on scale type
     x: null,
@@ -92,6 +96,10 @@ plugins: {
    //     return 'xy';
    //   },
    mode: 'xy',
+
+   // Which of the enabled zooming directions should only be available
+   // when the mouse cursor is over one of scale.
+   overScaleMode: 'xy',
 
    rangeMin: {
     // Format of min zoom range depends on scale type

--- a/samples/zoom-separately.html
+++ b/samples/zoom-separately.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html>
+
+<head>
+	<title>Chart.js Zoom each scale separately</title>
+	<script src="../node_modules/chart.js/dist/chart.js"></script>
+	<script src="../node_modules/hammerjs/hammer.min.js"></script>
+	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
+
+	<style>
+	canvas {
+		-moz-user-select: none;
+		-webkit-user-select: none;
+		-ms-user-select: none;
+	}
+	</style>
+</head>
+
+<body>
+	<canvas id="canvas"></canvas>
+	<script>
+		function genData() {
+			var analogData = [];
+			var digitalData = [];
+			var angle = 1980;
+			var limit = 35;
+			for (var x = 0; x <= angle; x += 10) {
+				var y = Math.sin(x * Math.PI / 180) * limit;
+				analogData.push({x, y});
+
+				y = x === 0 ? -limit : x === angle ? limit : y;
+				if (y === limit || y === -limit) {
+					digitalData.push({x, y: y === -limit});
+				}
+			}
+
+			return [analogData, digitalData];
+		}
+
+		function createConfig() {
+			var [analogData, digitalData] = genData();
+			return {
+				data: {
+					datasets: [{
+						yAxisID: 'yA',
+						label: 'Temperature',
+						type: 'line',
+						fill: false,
+						borderColor: 'rgb(54, 162, 235)',
+						data: analogData
+					}, {
+						yAxisID: 'yB',
+						label: 'Heater',
+						type: 'line',
+						fill: false,
+						steppedLine: true,
+						borderColor: 'rgb(255, 99, 132)',
+						data: digitalData
+					}]
+				},
+				options: {
+					responsive: true,
+					title: {
+						display: true,
+						text: 'Chart.js Zoom each scale separately'
+					},
+					scales: {
+						x: {
+							type: 'linear',
+							offset: true,
+							scaleLabel: {
+								display: true,
+								labelString: 'x axis'
+							}
+						},
+						yA: {
+							id: 'A',
+							offset: true,
+							position: 'left',
+							scaleLabel: {
+								display: true,
+								labelString: 'Analog'
+							}
+						},
+						yB: {
+							id: 'B',
+							position: 'right',
+							scaleLabel: {
+								display: true,
+								labelString: 'Digital'
+							},
+							ticks: {
+								max: 2,
+								min: -1,
+								stepSize: 1
+							}
+						}
+					},
+					plugins: {
+						zoom: {
+							pan: {
+								enabled: true,
+								mode: 'xy',
+								overScaleMode: 'y'
+							},
+							zoom: {
+								enabled: true,
+								mode: 'xy',
+								overScaleMode: 'y'
+							}
+						}
+					}
+				}
+			};
+		}
+
+		window.onload = function() {
+			var ctx = document.getElementById('canvas').getContext('2d');
+			var config = createConfig();
+			window.myChart = new window.Chart(ctx, config);
+		};
+	</script>
+</body>
+
+</html>

--- a/test/specs/zoom.spec.js
+++ b/test/specs/zoom.spec.js
@@ -314,4 +314,86 @@ describe('zoom', function() {
       }
     }
   });
+
+  describe('with overScaleMode = y and mode = xy', function() {
+    let config = {
+      type: 'line',
+      data,
+      options: {
+        scales: {
+          x: {
+            type: 'linear',
+            min: 1,
+            max: 10
+          },
+          y: {
+            type: 'linear'
+          }
+        },
+        plugins: {
+          zoom: {
+            zoom: {
+              enabled: true,
+              mode: 'xy',
+              overScaleMode: 'y'
+            }
+          }
+        }
+      }
+    };
+
+    describe('Wheel under Y scale', function() {
+      it('should be applied on Y, but not on X scales.', async function() {
+        const chart = window.acquireChart(config);
+
+        const scaleX = chart.scales.x;
+        const scaleY = chart.scales.y;
+
+        const oldMinX = scaleX.options.min;
+        const oldMaxX = scaleX.options.max;
+        const oldMinY = scaleY.options.min;
+        const oldMaxY = scaleY.options.max;
+
+        const wheelEv = {
+          x: scaleY.left + (scaleY.right - scaleY.left) / 2,
+          y: scaleY.top + (scaleY.bottom - scaleY.top) / 2,
+          deltaY: 1
+        };
+
+        await jasmine.triggerWheelEvent(chart, wheelEv);
+
+        expect(scaleX.options.min).toEqual(oldMinX);
+        expect(scaleX.options.max).toEqual(oldMaxX);
+        expect(scaleY.options.min).not.toEqual(oldMinY);
+        expect(scaleY.options.max).not.toEqual(oldMaxY);
+      });
+    });
+
+    describe('Wheel not under Y scale', function() {
+      it('should be applied on X, but not on Y scales.', async function() {
+        const chart = window.acquireChart(config);
+
+        const scaleX = chart.scales.x;
+        const scaleY = chart.scales.y;
+
+        const oldMinX = scaleX.options.min;
+        const oldMaxX = scaleX.options.max;
+        const oldMinY = scaleY.options.min;
+        const oldMaxY = scaleY.options.max;
+
+        const wheelEv = {
+          x: scaleX.getPixelForValue(1.5),
+          y: scaleY.getPixelForValue(1.1),
+          deltaY: 1
+        };
+
+        await jasmine.triggerWheelEvent(chart, wheelEv);
+
+        expect(scaleX.options.min).not.toEqual(oldMinX);
+        expect(scaleX.options.max).not.toEqual(oldMaxX);
+        expect(scaleY.options.min).toEqual(oldMinY);
+        expect(scaleY.options.max).toEqual(oldMaxY);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Added the **overScaleMode** option so that you can use zoom and pan separately for each scale when the mouse is over the scale.
Try it: https://codepen.io/lirik90/pen/rNLqMVg
Or watch what is it: https://youtu.be/u3HlB3YX_fs