### PR TITLE
Compatible with Chart.js 3.0.0-beta7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chartjs-plugin-zoom
 
-A zoom and pan plugin for Chart.js >= 3.0.0.
+A zoom and pan plugin for Chart.js >= 3.0.0-beta7.
 
 For Chart.js 2.6.0 to 2.9.x support, use [version 0.7.7 of this plugin](https://github.com/chartjs/chartjs-plugin-zoom/releases/tag/v0.7.7).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,9 +1098,9 @@
       "dev": true
     },
     "chart.js": {
-      "version": "3.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.0.0-beta.6.tgz",
-      "integrity": "sha512-Dq7veoux6ccaUHoA9Z5P5YvOqWWqLJcl3MNFZn+mYyyVqrtPbxXqWCzYwUlU7rovHcLy9FwoCSCGECcRN03FIg==",
+      "version": "3.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.0.0-beta.7.tgz",
+      "integrity": "sha512-UL0HlWNRBvvzGPoh0WfmsiaLuYdgjLj9PtutfEjL43eJxxDPHWmsqROJT7x81oyF6TVrFs2uR5UEkt0GfhGxxw==",
       "dev": true
     },
     "chokidar": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "gulp test"
   },
   "devDependencies": {
-    "chart.js": "^3.0.0-beta.6",
+    "chart.js": "^3.0.0-beta.7",
     "coveralls": "^3.1.0",
     "eslint": "^5.12.1",
     "eslint-config-chartjs": "^0.1.0",
@@ -49,7 +49,7 @@
     "yargs": "^15.3.1"
   },
   "peerDependencies": {
-    "chart.js": "^3.0.0-beta.6"
+    "chart.js": "^3.0.0-beta.7"
   },
   "dependencies": {
     "hammerjs": "^2.0.8"

--- a/samples/pan-bar.html
+++ b/samples/pan-bar.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Bar Chart Pan</title>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
 

--- a/samples/zoom-bar-x.html
+++ b/samples/zoom-bar-x.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Bar Chart Zoom</title>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
 

--- a/samples/zoom-bar.html
+++ b/samples/zoom-bar.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Bar Chart Zoom</title>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
 

--- a/samples/zoom-horizontal-bar.html
+++ b/samples/zoom-horizontal-bar.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Horizontal Bar Chart Zoom</title>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
 

--- a/samples/zoom-log.html
+++ b/samples/zoom-log.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Scatter Chart</title>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
 

--- a/samples/zoom-time.html
+++ b/samples/zoom-time.html
@@ -4,7 +4,7 @@
 <head>
 	<title>Line Chart</title>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.2"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.js"></script>

--- a/samples/zoom.html
+++ b/samples/zoom.html
@@ -3,7 +3,7 @@
 
 <head>
 	<title>Scatter Chart</title>
-	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.6"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.7"></script>
 	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
 	<script src="../dist/chartjs-plugin-zoom.min.js"></script>
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -388,7 +388,7 @@ var zoomPlugin = {
 		resolveOptions(chart, options);
 	},
 
-	beforeInit: function(chartInstance, pluginOptions) {
+	beforeInit: function(chartInstance, args, pluginOptions) {
 		chartInstance.$zoom = {
 			_originalOptions: {}
 		};

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -33,6 +33,6 @@ describe('defaults', function() {
 			}
 		});
 
-		expect(spy).toHaveBeenCalledWith(chart, {mode: undefined}, expected);
+		expect(spy).toHaveBeenCalledWith(chart, {cancelable: true, mode: undefined}, expected);
 	});
 });


### PR DESCRIPTION
Fixes #406, adapting the plugin to Charts.js 3.0.0-beta7