### PR TITLE
Properly call onZoom & onZoomComplete when pinching

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -535,8 +535,8 @@ var zoomPlugin = {
 				doZoom(chartInstance, diff, diff, center, xy);
 
 				var zoomOptions = chartInstance.$zoom._options.zoom;
-				if (typeof zoomOptions.onZoomComplete === 'function') {
-					zoomOptions.onZoomComplete({chart: chartInstance});
+				if (typeof zoomOptions.onZoom === 'function') {
+					zoomOptions.onZoom({chart: chartInstance});
 				}
 
 				// Keep track of overall scale
@@ -551,6 +551,10 @@ var zoomPlugin = {
 				handlePinch(e);
 				currentPinchScaling = null; // reset
 				zoomNS.zoomCumulativeDelta = 0;
+				var zoomOptions = chartInstance.$zoom._options.zoom;
+				if (typeof zoomOptions.onZoomComplete === 'function') {
+					zoomOptions.onZoomComplete({chart: chartInstance});
+				}
 			});
 
 			var currentDeltaX = null;


### PR DESCRIPTION
When pinching (normally on mobile devices), currently the `onZoomComplete` callback is being called continuously while pinching. This PR ensures `onZoom` is called continuously while pinching and `onZoomComplete` is called when pinch ends.

I believe the problem (as well as the feature itself) has been introduced with #269.

This should fix the problem reported in #305.