### PR TITLE
Restore .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: node_js
+node_js:
+  - "lts/*"
+
+before_install:
+  - "export CHROME_BIN=/usr/bin/google-chrome"
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+
+script:
+  - gulp test --coverage
+  - gulp build
+  - gulp package
+  - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls || true
+
+sudo: required
+dist: trusty
+
+addons:
+  chrome: stable
+  firefox: latest
+
+# IMPORTANT: scripts require GITHUB_AUTH_TOKEN and GITHUB_AUTH_EMAIL environment variables
+# IMPORTANT: scripts has to be set executables in the Git repository (error 127)
+# https://github.com/travis-ci/travis-ci/issues/5538#issuecomment-225025939
+
+deploy:
+  - provider: script
+    script: ./scripts/release.sh
+    skip_cleanup: true
+    on:
+      branch: release
+  - provider: releases
+    api_key: $GITHUB_AUTH_TOKEN
+    file:
+      - "./dist/chartjs-plugin-zoom.js"
+      - "./dist/chartjs-plugin-zoom.min.js"
+      - "./dist/chartjs-plugin-zoom.zip"
+    skip_cleanup: true
+    on:
+      tags: true
+  - provider: npm
+    email: $NPM_AUTH_EMAIL
+    api_key: $NPM_AUTH_TOKEN
+    skip_cleanup: true
+    on:
+      tags: true


### PR DESCRIPTION
I setup GitHub Actions in https://github.com/chartjs/chartjs-plugin-zoom/pull/402, but was too hasty in removing the `.travis.yml` file. We still need it for releases