### PR TITLE
Remove animationDuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ plugins: {
    //   borderColor: 'rgba(225,225,225,0.3)'
    //   borderWidth: 5,
    //   backgroundColor: 'rgb(225,225,225)',
-   //   animationDuration: 0
    // },
 
    // Zooming directions. Remove the appropriate direction to disable
@@ -130,6 +129,24 @@ plugins: {
    onZoomRejected: function({chart, event}) { console.log(`I didn't start zooming!`); }
   }
  }
+}
+```
+
+### Animations
+
+The drag-to-zoom can be animated by configuring the `zoom` transition in your chart config:
+
+```javascript
+{
+  options: {
+    transitions: {
+      zoom: {
+        animation: {
+          duration: 1000
+        }
+      }
+    }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ plugins: {
 
 ### Animations
 
-The drag-to-zoom can be animated by configuring the `zoom` transition in your chart config:
+The drag-to-zoom animation can be customized by configuring the `zoom` transition in your chart config:
 
 ```javascript
 {
@@ -142,7 +142,24 @@ The drag-to-zoom can be animated by configuring the `zoom` transition in your ch
     transitions: {
       zoom: {
         animation: {
-          duration: 1000
+          duration: 1000,
+          easing: 'easeOutCubic'
+        }
+      }
+    }
+  }
+}
+```
+
+If you want to disable zoom animations:
+
+```javascript
+{
+  options: {
+    transitions: {
+      zoom: {
+        animation: {
+          duration: 0
         }
       }
     }

--- a/samples/zoom-time.html
+++ b/samples/zoom-time.html
@@ -25,9 +25,6 @@
 	<script>
 		var timeFormat = 'MM/DD/YYYY HH:mm';
 		var now = window.moment();
-		var dragOptions = {
-			animationDuration: 1000
-		};
 
 		function randomScalingFactor() {
 			return Math.round(Math.random() * 100 * (Math.random() > 0.5 ? -1 : 1));
@@ -112,9 +109,16 @@
 					zoom: {
 						zoom: {
 							enabled: true,
-							drag: dragOptions,
+							drag: true,
 							mode: 'x',
 							speed: 0.05
+						}
+					}
+				},
+				transitions: {
+					zoom: {
+						animation: {
+							duration: 1000
 						}
 					}
 				}
@@ -136,7 +140,7 @@
 		window.toggleDragMode = function() {
 			var chart = window.myLine;
 			var zoomOptions = chart.options.plugins.zoom.zoom;
-			zoomOptions.drag = zoomOptions.drag ? false : dragOptions;
+			zoomOptions.drag = !zoomOptions.drag;
 
 			chart.update();
 			document.getElementById('drag-switch').innerText = zoomOptions.drag ? 'Disable drag mode' : 'Enable drag mode';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -184,9 +184,9 @@ function zoomScale(scale, zoom, center, zoomOptions) {
  * @param {number} percentZoomY The zoom percentage in the y direction
  * @param {{x: number, y: number}} [focalPoint] The x and y coordinates of zoom focal point. The point which doesn't change while zooming. E.g. the location of the mouse cursor when "drag: false"
  * @param {string} [whichAxes] `xy`, 'x', or 'y'
- * @param {string} [transitionMode] Mode used for update
+ * @param {boolean} [useTransition] Whether to use `zoom` transition
  */
-function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, transitionMode) {
+function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, useTransition) {
   var ca = chart.chartArea;
   if (!focalPoint) {
     focalPoint = {
@@ -225,11 +225,7 @@ function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, transi
       }
     });
 
-    if (transitionMode && chart.options.transitions[transitionMode]) {
-      chart.update(transitionMode);
-    } else {
-      chart.update('none');
-    }
+    chart.update(useTransition ? 'zoom' : 'none');
 
     if (typeof zoomOptions.onZoom === 'function') {
       zoomOptions.onZoom({chart: chart});
@@ -434,7 +430,7 @@ var zoomPlugin = {
       doZoom(chartInstance, zoomX, zoomY, {
         x: (startX - chartArea.left) / (1 - dragDistanceX / chartDistanceX) + chartArea.left,
         y: (startY - chartArea.top) / (1 - dragDistanceY / chartDistanceY) + chartArea.top
-      }, undefined, 'zoom');
+      }, undefined, true);
 
       if (typeof zoomOptions.onZoomComplete === 'function') {
         zoomOptions.onZoomComplete({chart: chartInstance});
@@ -643,6 +639,7 @@ var zoomPlugin = {
           delete scaleOptions.max;
         }
       });
+
       chartInstance.update('none');
     };
   },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -184,9 +184,9 @@ function zoomScale(scale, zoom, center, zoomOptions) {
  * @param {number} percentZoomY The zoom percentage in the y direction
  * @param {{x: number, y: number}} [focalPoint] The x and y coordinates of zoom focal point. The point which doesn't change while zooming. E.g. the location of the mouse cursor when "drag: false"
  * @param {string} [whichAxes] `xy`, 'x', or 'y'
- * @param {number} [animationDuration] Duration of the animation of the redraw in milliseconds
+ * @param {string} [transitionMode] Mode used for update
  */
-function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, animationDuration) {
+function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, transitionMode) {
   var ca = chart.chartArea;
   if (!focalPoint) {
     focalPoint = {
@@ -225,15 +225,8 @@ function doZoom(chart, percentZoomX, percentZoomY, focalPoint, whichAxes, animat
       }
     });
 
-    if (animationDuration) {
-      // needs to create specific animation mode
-      if (!chart.options.animation.zoom) {
-        chart.options.animation.zoom = {
-          duration: animationDuration,
-          easing: 'easeOutQuad',
-        };
-      }
-      chart.update('zoom');
+    if (transitionMode && chart.options.transitions[transitionMode]) {
+      chart.update(transitionMode);
     } else {
       chart.update('none');
     }
@@ -441,7 +434,7 @@ var zoomPlugin = {
       doZoom(chartInstance, zoomX, zoomY, {
         x: (startX - chartArea.left) / (1 - dragDistanceX / chartDistanceX) + chartArea.left,
         y: (startY - chartArea.top) / (1 - dragDistanceY / chartDistanceY) + chartArea.top
-      }, undefined, zoomOptions.drag.animationDuration);
+      }, undefined, 'zoom');
 
       if (typeof zoomOptions.onZoomComplete === 'function') {
         zoomOptions.onZoomComplete({chart: chartInstance});
@@ -650,7 +643,7 @@ var zoomPlugin = {
           delete scaleOptions.max;
         }
       });
-      chartInstance.update();
+      chartInstance.update('none');
     };
   },
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -7,7 +7,6 @@ export interface DragEffectOptions {
 	borderColor?: Color;
 	borderWidth?: number;
 	backgroundColor?: Color;
-	animationDuration?: number;
 }
 
 export interface RangePoint {
@@ -30,7 +29,7 @@ export interface ZoomOptions {
 	drag: boolean | DragEffectOptions;
 
 
-	/** 
+	/**
 	 * Zooming directions. Remove the appropriate direction to disable
 	 * Eg. 'y' would only allow zooming in the y direction
 	 * A function that is called as the user is zooming and returns the
@@ -38,20 +37,20 @@ export interface ZoomOptions {
 	 *    mode: function({ chart }) {
 	 *      return 'xy';
 	 *    },
-	 */	
+	 */
 	mode: Mode | { (char: Chart): Mode };
 
 	/**
 	 * Format of min zoom range depends on scale type
 	 */
 	rangeMin?: RangePoint;
-	
+
 	/**
 	 * Format of max zoom range depends on scale type
 	 */
 	rangeMax?: RangePoint;
 
-	/** 
+	/**
 	 * Speed of zoom via mouse wheel
 	 * (percentage of zoom on a wheel event)
 	 */
@@ -59,29 +58,29 @@ export interface ZoomOptions {
 
 	/**
 	 * Minimal zoom distance required before actually applying zoom
-	 */		
+	 */
 	threshold?: number;
 
 	/**
 	 * On category scale, minimal zoom level before actually applying zoom
-	 */	
+	 */
 	sensitivity?: number;
 
 	/**
 	 * Function called while the user is zooming
 	 */
 	onZoom?: (chart: Chart) => void;
-	
+
 	/**
 	 * Function called once zooming is completed
 	 */
 	onZoomComplete?: (chart: Chart) => void;
-	
+
 	/**
 	 * Function called when wheel input occurs without modifier key
 	 */
 	onZoomRejected?: (chart: Chart, event: Event) => void;
-	
+
 }
 
 /**
@@ -109,7 +108,7 @@ export interface PanOptions {
 	 * Format of min pan range depends on scale type
 	 */
 	rangeMin?: RangePoint;
-	
+
 	/**
 	 * Format of max pan range depends on scale type
 	 */
@@ -130,12 +129,12 @@ export interface PanOptions {
 	 * Function called while the user is panning
 	 */
 	onPan?: (chart: Chart) => void;
-	
+
 	/**
 	 * Function called once panning is completed
 	 */
 	onPanComplete?: (chart: Chart) => void;
-	
+
 	/**
 	 * Function called when pan fails because modifier key was not detected.
 	 * event is the a hammer event that failed - see https://hammerjs.github.io/api#event-object


### PR DESCRIPTION
As explained in #450, I suggest to remove the `animationDuration` option (not working with Chart.js 3) in favor of configuration of the `zoom` transition.

Closes #450 