### PR TITLE
Use fallback configration for scale types

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -17,7 +17,8 @@ function storeOriginalOptions(chart) {
 }
 
 function zoomScale(scale, zoom, center, zoomOptions) {
-  call(zoomFunctions[scale.type], [scale, zoom, center, zoomOptions]);
+  const fn = zoomFunctions[scale.type] || zoomFunctions.default;
+  call(fn, [scale, zoom, center, zoomOptions]);
 }
 
 /**
@@ -89,7 +90,8 @@ export function resetZoom(chart) {
 }
 
 function panScale(scale, delta, panOptions) {
-  call(panFunctions[scale.type], [scale, delta, panOptions]);
+  const fn = panFunctions[scale.type] || panFunctions.default;
+  call(fn, [scale, delta, panOptions]);
 }
 
 export function doPan(chart, deltaX, deltaY, panOptions, panningScales) {

--- a/src/scale.types.js
+++ b/src/scale.types.js
@@ -106,14 +106,10 @@ function panNumericalScale(scale, delta, panOptions) {
 
 export const zoomFunctions = {
   category: zoomCategoryScale,
-  time: zoomNumericalScale,
-  linear: zoomNumericalScale,
-  logarithmic: zoomNumericalScale,
+  default: zoomNumericalScale,
 };
 
 export const panFunctions = {
   category: panCategoryScale,
-  time: panNumericalScale,
-  linear: panNumericalScale,
-  logarithmic: panNumericalScale,
+  default: panNumericalScale,
 };


### PR DESCRIPTION
This enables the plugin to work with additional scale types, provided the scale works like a numerical scale.

Real example would be a `timeseries` scale that was not supported.