### PR TITLE
Changes zoom.threshold default to 0

### DIFF
--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -60,7 +60,7 @@ const chart = new Chart('id', {
 | `rangeMin` | `{x: any, y: any}` | `undefined` | Minimum zoom range allowed for the axes. Value type depends on the scale type
 | `rangeMax` | `{x: any, y: any}` | `undefined` | Maximum zoom range allowed for the axes. Value type depends on the scale type
 | `speed` | `number` | `0.1` | Factor of zoom speed via mouse wheel.
-| `threshold` | `number` | `10` | Mimimal zoom distance required before actually applying zoom
+| `threshold` | `number` | `0` | Mimimal zoom distance required before actually applying zoom
 
 ### Zoom Events
 


### PR DESCRIPTION
Reading the code, I have seen that threshold options for zoom, is initialized to 0:

https://github.com/chartjs/chartjs-plugin-zoom/blob/eded3899c7941b1f3d72a9da5bd705a660a8d14b/src/handlers.js#L82

Therefore I think the default could be document to 0, if I'm not wrong.