### PR TITLE
Refactor & export pan and zoom functions

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -69,6 +69,7 @@ module.exports = {
         'bar',
         'log',
         'time',
+        'api',
       ],
     }
   }

--- a/docs/samples/api.md
+++ b/docs/samples/api.md
@@ -1,0 +1,109 @@
+# API
+
+```js chart-editor
+// <block:data:1>
+const NUMBER_CFG = {count: 20, min: -100, max: 100};
+const data = {
+  datasets: [{
+    label: 'My First dataset',
+    borderColor: Utils.randomColor(0.4),
+    backgroundColor: Utils.randomColor(0.1),
+    pointBorderColor: Utils.randomColor(0.7),
+    pointBackgroundColor: Utils.randomColor(0.5),
+    pointBorderWidth: 1,
+    data: Utils.points(NUMBER_CFG),
+  }, {
+    label: 'My Second dataset',
+    borderColor: Utils.randomColor(0.4),
+    backgroundColor: Utils.randomColor(0.1),
+    pointBorderColor: Utils.randomColor(0.7),
+    pointBackgroundColor: Utils.randomColor(0.5),
+    pointBorderWidth: 1,
+    data: Utils.points(NUMBER_CFG),
+  }]
+};
+// </block:data>
+
+// <block:scales:2>
+const scaleOpts = {
+  reverse: true,
+  ticks: {
+    callback: (val, index, ticks) => index === 0 || index === ticks.length - 1 ? null : val,
+  },
+  grid: {
+    borderColor: Utils.randomColor(1),
+    color: 'rgba( 0, 0, 0, 0.1)',
+  },
+  title: {
+    display: true,
+    text: (ctx) => ctx.scale.axis + ' axis',
+  }
+};
+const scales = {
+  x: {
+    position: 'top',
+  },
+  y: {
+    position: 'right',
+  },
+};
+Object.keys(scales).forEach(scale => Object.assign(scales[scale], scaleOpts));
+// </block:scales>
+
+// <block:config:1>
+const config = {
+  type: 'scatter',
+  data: data,
+  options: {
+    scales: scales,
+  }
+};
+// </block:config>
+
+// <block:actions:0>
+// Note: changes to these actions are not applied to the buttons.
+const actions = [
+  {
+    name: 'Zoom +10%',
+    handler(chart) {
+      chart.zoom(1.1);
+    }
+  }, {
+    name: 'Zoom -10%',
+    handler(chart) {
+      chart.zoom(0.9);
+    },
+  }, {
+    name: 'Zoom x +10%',
+    handler(chart) {
+      chart.zoom({x: 1.1});
+    }
+  }, {
+    name: 'Zoom x -10%',
+    handler(chart) {
+      chart.zoom({x: 0.9});
+    },
+  }, {
+    name: 'Pan x 100px',
+    handler(chart) {
+      chart.pan({x: 100});
+    }
+  }, {
+    name: 'Pan x -100px',
+    handler(chart) {
+      chart.pan({x: -100});
+    },
+  }, {
+    name: 'Reset zoom',
+    handler(chart) {
+      chart.resetZoom();
+    }
+  }
+];
+// </block:actions>
+
+module.exports = {
+  actions,
+  config
+};
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
-        "chart.js": "^3.1.0",
-        "chartjs-adapter-date-fns": "^2.0.0",
+        "chart.js": "^3.2.0",
         "chartjs-test-utils": "^0.2.2",
         "concurrently": "^6.0.2",
         "coveralls": "^3.1.0",
@@ -50,7 +49,7 @@
         "vuepress-theme-chartjs": "^0.2.0"
       },
       "peerDependencies": {
-        "chart.js": "^3.0.0"
+        "chart.js": "^3.2.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "chart.js": "^3.1.0",
+    "chart.js": "^3.2.0",
     "chartjs-adapter-date-fns": "^2.0.0",
     "chartjs-test-utils": "^0.2.2",
     "concurrently": "^6.0.2",
@@ -71,7 +71,7 @@
     "vuepress-theme-chartjs": "^0.2.0"
   },
   "peerDependencies": {
-    "chart.js": "^3.0.0"
+    "chart.js": "^3.2.0"
   },
   "dependencies": {
     "hammerjs": "^2.0.8"

--- a/src/core.js
+++ b/src/core.js
@@ -43,14 +43,14 @@ export function doZoom(chart, zoom, options = {}, useTransition) {
 
   storeOriginalScaleLimits(chart);
 
-  const xEnalbed = directionEnabled(mode, 'x', chart);
-  const yEnabled = directionEnabled(mode, 'y', chart);
+  const xEnalbed = x !== 1 && directionEnabled(mode, 'x', chart);
+  const yEnabled = y !== 1 && directionEnabled(mode, 'y', chart);
   const enabledScales = overScaleMode && getEnabledScalesByPoint(overScaleMode, focalPoint, chart);
 
   each(enabledScales || chart.scales, function(scale) {
-    if (x !== 1 && scale.isHorizontal() && xEnalbed) {
+    if (scale.isHorizontal() && xEnalbed) {
       zoomScale(scale, x, focalPoint, options);
-    } else if (y !== 1 && !scale.isHorizontal() && yEnabled) {
+    } else if (!scale.isHorizontal() && yEnabled) {
       zoomScale(scale, y, focalPoint, options);
     }
   });
@@ -87,13 +87,13 @@ export function doPan(chart, pan, options = {}, enabledScales) {
 
   storeOriginalScaleLimits(chart);
 
-  const xEnalbed = directionEnabled(mode, 'x', chart);
-  const yEnabled = directionEnabled(mode, 'y', chart);
+  const xEnalbed = x !== 0 && directionEnabled(mode, 'x', chart);
+  const yEnabled = y !== 0 && directionEnabled(mode, 'y', chart);
 
   each(enabledScales || chart.scales, function(scale) {
-    if (x !== 0 && scale.isHorizontal() && xEnalbed) {
+    if (scale.isHorizontal() && xEnalbed) {
       panScale(scale, x, options);
-    } else if (y !== 0 && !scale.isHorizontal() && yEnabled) {
+    } else if (!scale.isHorizontal() && yEnabled) {
       panScale(scale, y, options);
     }
   });

--- a/src/core.js
+++ b/src/core.js
@@ -87,7 +87,7 @@ export function doPan(chart, pan, options = {}, enabledScales) {
 
   storeOriginalScaleLimits(chart);
 
-  const xEnabled= x !== 0 && directionEnabled(mode, 'x', chart);
+  const xEnabled = x !== 0 && directionEnabled(mode, 'x', chart);
   const yEnabled = y !== 0 && directionEnabled(mode, 'y', chart);
 
   each(enabledScales || chart.scales, function(scale) {

--- a/src/core.js
+++ b/src/core.js
@@ -23,50 +23,41 @@ function zoomScale(scale, zoom, center, zoomOptions) {
   call(fn, [scale, zoom, center, zoomOptions]);
 }
 
+function getCenter(chart) {
+  const ca = chart.chartArea;
+  return {
+    x: (ca.left + ca.right) / 2,
+    y: (ca.top + ca.bottom) / 2,
+  };
+}
+
 /**
  * @param chart The chart instance
- * @param {number} percentZoomX The zoom percentage in the x direction
- * @param {number} percentZoomY The zoom percentage in the y direction
- * @param {{x: number, y: number}} focalPoint The x and y coordinates of zoom focal point. The point which doesn't change while zooming. E.g. the location of the mouse cursor when "drag: false"
- * @param {object} zoomOptions The zoom options
- * @param {string} [whichAxes] `xy`, 'x', or 'y'
+ * @param {number | {x?: number, y?: number, focalPoint?: {x: number, y: number}}} zoom The zoom percentage or percentages and focal point
+ * @param {object} [options] The zoom options
  * @param {boolean} [useTransition] Whether to use `zoom` transition
  */
-export function doZoom(chart, percentZoomX, percentZoomY, focalPoint, zoomOptions, whichAxes, useTransition) {
-  if (!focalPoint) {
-    const ca = chart.chartArea;
-    focalPoint = {
-      x: (ca.left + ca.right) / 2,
-      y: (ca.top + ca.bottom) / 2,
-    };
-  }
+export function doZoom(chart, zoom, options = {}, useTransition) {
+  const {x = 1, y = 1, focalPoint = getCenter(chart)} = typeof zoom === 'number' ? {x: zoom, y: zoom} : zoom;
+  const {mode = 'xy', overScaleMode} = options;
 
   storeOriginalScaleLimits(chart);
-  // Do the zoom here
-  const zoomMode = typeof zoomOptions.mode === 'function' ? zoomOptions.mode({chart: chart}) : zoomOptions.mode;
 
-  // Which axes should be modified when fingers were used.
-  let _whichAxes;
-  if (zoomMode === 'xy' && whichAxes !== undefined) {
-    // based on fingers positions
-    _whichAxes = whichAxes;
-  } else {
-    // no effect
-    _whichAxes = 'xy';
-  }
+  const xEnalbed = directionEnabled(mode, 'x', chart);
+  const yEnabled = directionEnabled(mode, 'y', chart);
+  const enabledScales = overScaleMode && getEnabledScalesByPoint(overScaleMode, focalPoint, chart);
 
-  const enabledScales = getEnabledScalesByPoint(zoomOptions, focalPoint.x, focalPoint.y, chart);
   each(enabledScales || chart.scales, function(scale) {
-    if (scale.isHorizontal() && directionEnabled(zoomMode, 'x', chart) && directionEnabled(_whichAxes, 'x', chart)) {
-      zoomScale(scale, percentZoomX, focalPoint, zoomOptions);
-    } else if (!scale.isHorizontal() && directionEnabled(zoomMode, 'y', chart) && directionEnabled(_whichAxes, 'y', chart)) {
-      zoomScale(scale, percentZoomY, focalPoint, zoomOptions);
+    if (x !== 1 && scale.isHorizontal() && xEnalbed) {
+      zoomScale(scale, x, focalPoint, options);
+    } else if (y !== 1 && !scale.isHorizontal() && yEnabled) {
+      zoomScale(scale, y, focalPoint, options);
     }
   });
 
   chart.update(useTransition ? 'zoom' : 'none');
 
-  call(zoomOptions.onZoom, [chart]);
+  call(options.onZoom, [chart]);
 }
 
 export function resetZoom(chart) {
@@ -90,22 +81,25 @@ function panScale(scale, delta, panOptions) {
   call(fn, [scale, delta, panOptions]);
 }
 
-export function doPan(chart, deltaX, deltaY, panOptions, panningScales) {
+export function doPan(chart, pan, options = {}, enabledScales) {
+  const {x = 0, y = 0} = typeof pan === 'number' ? {x: pan, y: pan} : pan;
+  const {mode = 'xy', onPan} = options;
+
   storeOriginalScaleLimits(chart);
-  if (panOptions.enabled) {
-    const panMode = typeof panOptions.mode === 'function' ? panOptions.mode({chart}) : panOptions.mode;
 
-    each(panningScales || chart.scales, function(scale) {
-      if (scale.isHorizontal() && directionEnabled(panMode, 'x', chart) && deltaX !== 0) {
-        panScale(scale, deltaX, panOptions);
-      } else if (!scale.isHorizontal() && directionEnabled(panMode, 'y', chart) && deltaY !== 0) {
-        panScale(scale, deltaY, panOptions);
-      }
-    });
+  const xEnalbed = directionEnabled(mode, 'x', chart);
+  const yEnabled = directionEnabled(mode, 'y', chart);
 
-    chart.update('none');
+  each(enabledScales || chart.scales, function(scale) {
+    if (x !== 0 && scale.isHorizontal() && xEnalbed) {
+      panScale(scale, x, options);
+    } else if (y !== 0 && !scale.isHorizontal() && yEnabled) {
+      panScale(scale, y, options);
+    }
+  });
 
-    call(panOptions.onPan, [chart]);
-  }
+  chart.update('none');
+
+  call(onPan, [chart]);
 }
 

--- a/src/core.js
+++ b/src/core.js
@@ -43,12 +43,12 @@ export function doZoom(chart, zoom, options = {}, useTransition) {
 
   storeOriginalScaleLimits(chart);
 
-  const xEnalbed = x !== 1 && directionEnabled(mode, 'x', chart);
+  const xEnabled = x !== 1 && directionEnabled(mode, 'x', chart);
   const yEnabled = y !== 1 && directionEnabled(mode, 'y', chart);
   const enabledScales = overScaleMode && getEnabledScalesByPoint(overScaleMode, focalPoint, chart);
 
   each(enabledScales || chart.scales, function(scale) {
-    if (scale.isHorizontal() && xEnalbed) {
+    if (scale.isHorizontal() && xEnabled) {
       zoomScale(scale, x, focalPoint, options);
     } else if (!scale.isHorizontal() && yEnabled) {
       zoomScale(scale, y, focalPoint, options);
@@ -87,11 +87,11 @@ export function doPan(chart, pan, options = {}, enabledScales) {
 
   storeOriginalScaleLimits(chart);
 
-  const xEnalbed = x !== 0 && directionEnabled(mode, 'x', chart);
+  const xEnabled= x !== 0 && directionEnabled(mode, 'x', chart);
   const yEnabled = y !== 0 && directionEnabled(mode, 'y', chart);
 
   each(enabledScales || chart.scales, function(scale) {
-    if (scale.isHorizontal() && xEnalbed) {
+    if (scale.isHorizontal() && xEnabled) {
       panScale(scale, x, options);
     } else if (!scale.isHorizontal() && yEnabled) {
       panScale(scale, y, options);

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -92,8 +92,8 @@ function handlePan(chart, state, e) {
 }
 
 function startPan(chart, state, e) {
-  const panOptions = state.options.pan;
-  if (!panOptions.enabled) {
+  const {enabled, overScaleMode} = state.options.pan;
+  if (!enabled) {
     return;
   }
   const rect = e.target.getBoundingClientRect();
@@ -102,7 +102,7 @@ function startPan(chart, state, e) {
     y: e.center.y - rect.top
   };
 
-  state.panScales = getEnabledScalesByPoint(panOptions.overScaleMode, point, chart);
+  state.panScales = overScaleMode && getEnabledScalesByPoint(overScaleMode, point, chart);
   state.delta = {x: 0, y: 0};
   handlePan(chart, state, e);
 }

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -2,7 +2,7 @@ import {callback as call} from 'chart.js/helpers';
 import Hammer from 'hammerjs';
 import {doPan, doZoom} from './core';
 import {getState} from './state';
-import {getEnabledScalesByPoint} from './utils';
+import {directionEnabled, getEnabledScalesByPoint} from './utils';
 
 function createEnabler(chart) {
   const state = getState(chart);
@@ -26,28 +26,41 @@ function createEnabler(chart) {
 
 function pinchAxes(p0, p1) {
   // fingers position difference
-  const x = Math.abs(p0.clientX - p1.clientX);
-  const y = Math.abs(p0.clientY - p1.clientY);
+  const pinchX = Math.abs(p0.clientX - p1.clientX);
+  const pinchY = Math.abs(p0.clientY - p1.clientY);
 
   // diagonal fingers will change both (xy) axes
-  const p = x / y;
-  return p > 0.3 && p < 1.7 ? 'xy' : x > y ? 'x' : 'y';
+  const p = pinchX / pinchY;
+  let x, y;
+  if (p > 0.3 && p < 1.7) {
+    x = y = true;
+  } else if (pinchX > pinchY) {
+    x = true;
+  } else {
+    y = true;
+  }
+  return {x, y};
 }
 
 function handlePinch(chart, state, e) {
   if (state.scale) {
     const {center, pointers} = e;
     // Hammer reports the total scaling. We need the incremental amount
-    const zoom = 1 / state.scale * e.scale;
+    const zoomPercent = 1 / state.scale * e.scale;
     const rect = e.target.getBoundingClientRect();
-    const focalPoint = {
-      x: center.x - rect.left,
-      y: center.y - rect.top
+    const pinch = pinchAxes(pointers[0], pointers[1]);
+    const options = state.options.zoom;
+    const mode = options.mode;
+    const zoom = {
+      x: pinch.x && directionEnabled(mode, 'x', chart) ? zoomPercent : 1,
+      y: pinch.y && directionEnabled(mode, 'y', chart) ? zoomPercent : 1,
+      focalPoint: {
+        x: center.x - rect.left,
+        y: center.y - rect.top
+      }
     };
 
-    const xy = pinchAxes(pointers[0], pointers[1]);
-
-    doZoom(chart, zoom, zoom, focalPoint, state.options.zoom, xy);
+    doZoom(chart, zoom, options);
 
     // Keep track of overall scale
     state.scale = e.scale;
@@ -73,7 +86,7 @@ function handlePan(chart, state, e) {
   const delta = state.delta;
   if (delta !== null) {
     state.panning = true;
-    doPan(chart, e.deltaX - delta.x, e.deltaY - delta.y, state.options.pan, state.panScales);
+    doPan(chart, {x: e.deltaX - delta.x, y: e.deltaY - delta.y}, state.options.pan, state.panScales);
     state.delta = {x: e.deltaX, y: e.deltaY};
   }
 }
@@ -84,10 +97,12 @@ function startPan(chart, state, e) {
     return;
   }
   const rect = e.target.getBoundingClientRect();
-  const x = e.center.x - rect.left;
-  const y = e.center.y - rect.top;
+  const point = {
+    x: e.center.x - rect.left,
+    y: e.center.y - rect.top
+  };
 
-  state.panScales = getEnabledScalesByPoint(panOptions, x, y, chart);
+  state.panScales = getEnabledScalesByPoint(panOptions, point, chart);
   state.delta = {x: 0, y: 0};
   handlePan(chart, state, e);
 }

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -102,7 +102,7 @@ function startPan(chart, state, e) {
     y: e.center.y - rect.top
   };
 
-  state.panScales = getEnabledScalesByPoint(panOptions, point, chart);
+  state.panScales = getEnabledScalesByPoint(panOptions.overScaleMode, point, chart);
   state.delta = {x: 0, y: 0};
   handlePan(chart, state, e);
 }

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -85,11 +85,15 @@ export function mouseUp(chart, event) {
   }
 
   const {top, left, width, height} = chart.chartArea;
-  const focalPoint = {
-    x: (rect.left - left) / (1 - dragDistanceX / width) + left,
-    y: (rect.top - top) / (1 - dragDistanceY / height) + top
+  const zoom = {
+    x: rect.zoomX,
+    y: rect.zoomY,
+    focalPoint: {
+      x: (rect.left - left) / (1 - dragDistanceX / width) + left,
+      y: (rect.top - top) / (1 - dragDistanceY / height) + top
+    }
   };
-  doZoom(chart, rect.zoomX, rect.zoomY, focalPoint, zoomOptions, undefined, true);
+  doZoom(chart, zoom, zoomOptions, true);
 
   call(zoomOptions.onZoomComplete, [chart]);
 }
@@ -116,12 +120,16 @@ export function wheel(chart, event) {
 
   const rect = event.target.getBoundingClientRect();
   const speed = 1 + (event.deltaY >= 0 ? -zoomOptions.speed : zoomOptions.speed);
-  const center = {
-    x: event.clientX - rect.left,
-    y: event.clientY - rect.top
+  const zoom = {
+    x: speed,
+    y: speed,
+    focalPoint: {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    }
   };
 
-  doZoom(chart, speed, speed, center, zoomOptions);
+  doZoom(chart, zoom, zoomOptions);
 
   if (onZoomComplete) {
     debounce(() => call(onZoomComplete, [{chart}]), 250);

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,3 +1,4 @@
 import plugin from './plugin';
 
 export default plugin;
+export {doPan, doZoom, resetZoom} from './core';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,7 +1,7 @@
 import Hammer from 'hammerjs';
 import {addListeners, computeDragRect, removeListeners} from './handlers';
 import {startHammer, stopHammer} from './hammer';
-import {resetZoom} from './core';
+import {doPan, doZoom, resetZoom} from './core';
 import {getState, removeState} from './state';
 import {version} from '../package.json';
 
@@ -34,6 +34,8 @@ export default {
       startHammer(chart, options);
     }
 
+    chart.pan = (pan, panOptions, panScales) => doPan(chart, pan, panOptions, panScales);
+    chart.zoom = (zoom, zoomOptions, useTransition) => doZoom(chart, zoom, zoomOptions, useTransition);
     chart.resetZoom = () => resetZoom(chart);
   },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,11 +38,11 @@ export function debounce(fn, delay) {
 }
 
 /** This function use for check what axis now under mouse cursor.
- * @param {number} [x] X position
- * @param {number} [y] Y position
+ * @param {{x: number, y: number}} point - the mouse location
  * @param {import('chart.js').Chart} [chart] instance of the chart in question
+ * @return {import('chart.js').Scale}
  */
-function getScaleUnderPoint(x, y, chart) {
+function getScaleUnderPoint({x, y}, chart) {
   const scales = chart.scales;
   const scaleIds = Object.keys(scales);
   for (let i = 0; i < scaleIds.length; i++) {
@@ -60,27 +60,23 @@ function getScaleUnderPoint(x, y, chart) {
  * and other directions in 'mode' works as before.
  * Example: mode = 'xy', overScaleMode = 'y' -> it's means 'x' - works as before, and 'y' only works for one scale when cursor is under it.
  * options.overScaleMode can be a function if user want zoom only one scale of many for example.
- * @param {any} [options] pan or zoom options
- * @param {number} [x] X position
- * @param {number} [y] Y position
+ * @param {string} mode - 'xy', 'x' or 'y'
+ * @param {{x: number, y: number}} point - the mouse location
  * @param {import('chart.js').Chart} [chart] instance of the chart in question
+ * @return {import('chart.js').Scale[]}
  */
-export function getEnabledScalesByPoint(options, x, y, chart) {
-  if (options.enabled && options.overScaleMode) {
-    const scale = getScaleUnderPoint(x, y, chart);
-    const mode = typeof options.overScaleMode === 'function' ? options.overScaleMode({chart: chart}, scale) : options.overScaleMode;
+export function getEnabledScalesByPoint(mode, point, chart) {
+  const scale = getScaleUnderPoint(point, chart);
 
-    if (scale && directionEnabled(mode, scale.axis, chart)) {
-      return [scale];
-    }
-
-    const enabledScales = [];
-    each(chart.scales, function(scaleItem) {
-      if (!directionEnabled(mode, scaleItem.axis, chart)) {
-        enabledScales.push(scaleItem);
-      }
-    });
-    return enabledScales;
+  if (scale && directionEnabled(mode, scale.axis, chart)) {
+    return [scale];
   }
-  return null;
+
+  const enabledScales = [];
+  each(chart.scales, function(scaleItem) {
+    if (!directionEnabled(mode, scaleItem.axis, chart)) {
+      enabledScales.push(scaleItem);
+    }
+  });
+  return enabledScales;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,27 @@
-import { Plugin, ChartType } from 'chart.js';
-import { ZoomPluginOptions } from './options';
+import { Plugin, ChartType, Chart, Scale } from 'chart.js';
+import { DistributiveArray } from 'chart.js/types/utils';
+import { PanOptions, ZoomOptions, ZoomPluginOptions } from './options';
 
+type Point = { x: number, y: number };
+type ZoomAmount = number | Partial<Point> & { focalPoint?: Point };
+type PanAmount = number | Partial<Point>;
 declare module 'chart.js' {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	interface PluginOptionsByType<TType extends ChartType> {
     zoom: ZoomPluginOptions;
-	}
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface Chart<TType extends keyof ChartTypeRegistry = keyof ChartTypeRegistry, TData = DistributiveArray<ChartTypeRegistry[TType]['defaultDataPoint']>, TLabel = unknown> {
+    resetZoom(): void;
+    pan(pan: PanAmount, options?: Partial<PanOptions>, scales?: Scale[]);
+    zoom(zoom: ZoomAmount, options?: Partial<ZoomOptions>, useTransition?: boolean);
+  }
 }
 
-export declare const Zoom: Plugin;
+declare const Zoom: Plugin;
+
+export default Zoom;
+
+export function doPan(chart: Chart, pan: PanAmount, options?: Partial<PanOptions>, scales?: Scale[]);
+export function doZoom(chart: Chart, zoom: ZoomAmount, options?: Partial<ZoomOptions>, useTransition?: boolean);
+export function resetZoom(chart: Chart);

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -40,6 +40,8 @@ export interface ZoomOptions {
 	 */
 	mode: Mode | { (char: Chart): Mode };
 
+  overScaleMode: Mode | { (char: Chart): Mode };
+
 	/**
 	 * Format of min zoom range depends on scale type
 	 */
@@ -97,7 +99,9 @@ export interface PanOptions {
 	 *     return 'xy';
 	 *   },
 	 */
-	mode: Mode | { (char: Chart): Mode };
+  mode: Mode | { (char: Chart): Mode };
+
+  overScaleMode: Mode | { (char: Chart): Mode };
 
 	/**
 	 * Format of min pan range depends on scale type

--- a/types/tests/exports.ts
+++ b/types/tests/exports.ts
@@ -1,5 +1,5 @@
 import { Chart } from 'chart.js';
-import { Zoom } from '../index';
+import Zoom, { doPan, doZoom, resetZoom } from '../index';
 
 Chart.register(Zoom);
 Chart.unregister(Zoom);
@@ -29,3 +29,14 @@ const chart = new Chart('id', {
   },
   plugins: [Zoom]
 });
+
+chart.resetZoom();
+chart.zoom(1.1);
+chart.zoom({ x: 1, y: 1.1, focalPoint: { x: 10, y: 10 } }, { overScaleMode: 'xy' }, true);
+
+chart.pan(10);
+chart.pan({ x: 10, y: 20 }, { overScaleMode: 'xy' }, [chart.scales.x]);
+
+doPan(chart, -42);
+doZoom(chart, { x: 1, y: 1.1, focalPoint: { x: 10, y: 10 } }, { overScaleMode: 'xy' }, true);
+resetZoom(chart);


### PR DESCRIPTION
* Simplify the `doPan` and `doZoom` interface.
* export doPan, doZoom and resetZoom functions.
* add `pan` and `zoom` functions to chart instance.
* Add sample
* 