### PR TITLE
Add zoomScale, rename doPan to pan, doZoom to zoom

### DIFF
--- a/docs/samples/api.md
+++ b/docs/samples/api.md
@@ -84,15 +84,21 @@ const actions = [
       chart.zoom({x: 0.9});
     },
   }, {
-    name: 'Pan x 100px',
+    name: 'Pan x 100px (anim)',
     handler(chart) {
-      chart.pan({x: 100});
+      chart.pan({x: 100}, undefined, 'default');
     }
   }, {
-    name: 'Pan x -100px',
+    name: 'Pan x -100px (anim)',
     handler(chart) {
-      chart.pan({x: -100});
+      chart.pan({x: -100}, undefined, 'default');
     },
+  }, {
+    name: 'Zoom x: 0..-100, y: 0..100',
+    handler(chart) {
+      chart.zoomScale('x', -100, 0, 'default');
+      chart.zoomScale('y', 0, 100, 'default');
+    }
   }, {
     name: 'Reset zoom',
     handler(chart) {

--- a/docs/samples/api.md
+++ b/docs/samples/api.md
@@ -96,8 +96,8 @@ const actions = [
   }, {
     name: 'Zoom x: 0..-100, y: 0..100',
     handler(chart) {
-      chart.zoomScale('x', -100, 0, 'default');
-      chart.zoomScale('y', 0, 100, 'default');
+      chart.zoomScale('x', {min: -100, max: 0}, 'default');
+      chart.zoomScale('y', {min: 0, max: 100}, 'default');
     }
   }, {
     name: 'Reset zoom',

--- a/docs/samples/time.md
+++ b/docs/samples/time.md
@@ -106,7 +106,21 @@ const actions = [
     handler(chart) {
       chart.resetZoom();
     }
+  }, {
+    name: 'Zoom to next week',
+    handler(chart) {
+      const limits = Utils.nextWeek();
+      chart.zoomScale('x', limits.min, limits.max, 'default');
+      chart.update();
+    }
+  }, {
+    name: 'Zoom to 400-600',
+    handler(chart) {
+      chart.zoomScale('y', 400, 600, 'default');
+      chart.update();
+    }
   }
+
 ];
 
 module.exports = {

--- a/docs/samples/time.md
+++ b/docs/samples/time.md
@@ -109,14 +109,13 @@ const actions = [
   }, {
     name: 'Zoom to next week',
     handler(chart) {
-      const limits = Utils.nextWeek();
-      chart.zoomScale('x', limits.min, limits.max, 'default');
+      chart.zoomScale('x', Utils.nextWeek(), 'default');
       chart.update();
     }
   }, {
     name: 'Zoom to 400-600',
     handler(chart) {
-      chart.zoomScale('y', 400, 600, 'default');
+      chart.zoomScale('y', {min: 400, max: 600}, 'default');
       chart.update();
     }
   }

--- a/docs/scripts/utils.js
+++ b/docs/scripts/utils.js
@@ -1,5 +1,5 @@
 import {valueOrDefault} from 'chart.js/helpers';
-import {addHours} from 'date-fns';
+import {addHours, startOfWeek, endOfWeek} from 'date-fns';
 
 // Adapted from http://indiegamr.com/generate-repeatable-random-numbers-in-js/
 let _seed = Date.now();
@@ -85,4 +85,13 @@ export function hourlyPoints(config) {
   const ys = this.numbers(config);
   const start = new Date().valueOf();
   return ys.map((y, i) => ({x: addHours(start, i), y}));
+}
+
+export function nextWeek() {
+  const now = new Date().valueOf();
+  const min = startOfWeek(addHours(endOfWeek(now), 24));
+  return {
+    min: +min,
+    max: +endOfWeek(min)
+  };
 }

--- a/src/core.js
+++ b/src/core.js
@@ -61,10 +61,10 @@ export function zoom(chart, amount, transition = 'none') {
 }
 
 
-export function zoomScale(chart, scaleId, min, max, transition = 'none') {
+export function zoomScale(chart, scaleId, range, transition = 'none') {
   storeOriginalScaleLimits(chart);
   const scale = chart.scales[scaleId];
-  updateRange(scale, {min, max}, undefined, true);
+  updateRange(scale, range, undefined, true);
   chart.update(transition);
 }
 

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -1,6 +1,6 @@
 import {callback as call} from 'chart.js/helpers';
 import Hammer from 'hammerjs';
-import {doPan, doZoom} from './core';
+import {pan, zoom} from './core';
 import {getState} from './state';
 import {directionEnabled, getEnabledScalesByPoint} from './utils';
 
@@ -50,7 +50,7 @@ function handlePinch(chart, state, e) {
     const rect = e.target.getBoundingClientRect();
     const pinch = pinchAxes(pointers[0], pointers[1]);
     const mode = state.options.zoom.mode;
-    const zoom = {
+    const amount = {
       x: pinch.x && directionEnabled(mode, 'x', chart) ? zoomPercent : 1,
       y: pinch.y && directionEnabled(mode, 'y', chart) ? zoomPercent : 1,
       focalPoint: {
@@ -59,7 +59,7 @@ function handlePinch(chart, state, e) {
       }
     };
 
-    doZoom(chart, zoom);
+    zoom(chart, amount);
 
     // Keep track of overall scale
     state.scale = e.scale;
@@ -84,7 +84,7 @@ function handlePan(chart, state, e) {
   const delta = state.delta;
   if (delta !== null) {
     state.panning = true;
-    doPan(chart, {x: e.deltaX - delta.x, y: e.deltaY - delta.y}, state.panScales);
+    pan(chart, {x: e.deltaX - delta.x, y: e.deltaY - delta.y}, state.panScales);
     state.delta = {x: e.deltaX, y: e.deltaY};
   }
 }

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,5 +1,5 @@
 import {directionEnabled, debounce} from './utils';
-import {doZoom} from './core';
+import {zoom} from './core';
 import {callback as call} from 'chart.js/helpers';
 import {getState} from './state';
 
@@ -85,7 +85,7 @@ export function mouseUp(chart, event) {
   }
 
   const {top, left, width, height} = chart.chartArea;
-  const zoom = {
+  const amount = {
     x: rect.zoomX,
     y: rect.zoomY,
     focalPoint: {
@@ -93,7 +93,7 @@ export function mouseUp(chart, event) {
       y: (rect.top - top) / (1 - dragDistanceY / height) + top
     }
   };
-  doZoom(chart, zoom, true);
+  zoom(chart, amount, 'zoom');
 
   call(zoomOptions.onZoomComplete, [chart]);
 }
@@ -120,7 +120,7 @@ export function wheel(chart, event) {
 
   const rect = event.target.getBoundingClientRect();
   const speed = 1 + (event.deltaY >= 0 ? -zoomOptions.speed : zoomOptions.speed);
-  const zoom = {
+  const amount = {
     x: speed,
     y: speed,
     focalPoint: {
@@ -129,7 +129,7 @@ export function wheel(chart, event) {
     }
   };
 
-  doZoom(chart, zoom);
+  zoom(chart, amount);
 
   if (onZoomComplete) {
     debounce(() => call(onZoomComplete, [{chart}]), 250);

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,4 +1,4 @@
 import plugin from './plugin';
 
 export default plugin;
-export {doPan, doZoom, resetZoom} from './core';
+export {pan, zoom, zoomScale, resetZoom} from './core';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,7 +1,7 @@
 import Hammer from 'hammerjs';
 import {addListeners, computeDragRect, removeListeners} from './handlers';
 import {startHammer, stopHammer} from './hammer';
-import {doPan, doZoom, resetZoom} from './core';
+import {pan, zoom, resetZoom, zoomScale} from './core';
 import {panFunctions, zoomFunctions} from './scale.types';
 import {getState, removeState} from './state';
 import {version} from '../package.json';
@@ -26,7 +26,7 @@ export default {
     }
   },
 
-  start: function(chart, args, options) {
+  start: function(chart, _args, options) {
     const state = getState(chart);
     state.options = options;
 
@@ -34,8 +34,9 @@ export default {
       startHammer(chart, options);
     }
 
-    chart.pan = (pan, panScales) => doPan(chart, pan, panScales);
-    chart.zoom = (zoom, useTransition) => doZoom(chart, zoom, useTransition);
+    chart.pan = (delta, panScales, transition) => pan(chart, delta, panScales, transition);
+    chart.zoom = (args, transition) => zoom(chart, args, transition);
+    chart.zoomScale = (id, min, max, transition) => zoomScale(chart, id, min, max, transition);
     chart.resetZoom = () => resetZoom(chart);
   },
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,7 +36,7 @@ export default {
 
     chart.pan = (delta, panScales, transition) => pan(chart, delta, panScales, transition);
     chart.zoom = (args, transition) => zoom(chart, args, transition);
-    chart.zoomScale = (id, min, max, transition) => zoomScale(chart, id, min, max, transition);
+    chart.zoomScale = (id, range, transition) => zoomScale(chart, id, range, transition);
     chart.resetZoom = () => resetZoom(chart);
   },
 

--- a/src/scale.types.js
+++ b/src/scale.types.js
@@ -12,7 +12,7 @@ function zoomDelta(scale, zoom, center) {
   };
 }
 
-function updateRange(scale, {min, max}, limits, zoom = false) {
+export function updateRange(scale, {min, max}, limits, zoom = false) {
   const {axis, options: scaleOpts} = scale;
   const {min: minLimit = -Infinity, max: maxLimit = Infinity, minRange = 0} = limits && limits[axis] || {};
   const cmin = Math.max(min, minLimit);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,8 @@ import { ZoomPluginOptions } from './options';
 type Point = { x: number, y: number };
 type ZoomAmount = number | Partial<Point> & { focalPoint?: Point };
 type PanAmount = number | Partial<Point>;
+type ScaleRange = { min: number, max: number };
+
 declare module 'chart.js' {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	interface PluginOptionsByType<TType extends ChartType> {
@@ -19,7 +21,7 @@ declare module 'chart.js' {
   interface Chart<TType extends keyof ChartTypeRegistry = keyof ChartTypeRegistry, TData = DistributiveArray<ChartTypeRegistry[TType]['defaultDataPoint']>, TLabel = unknown> {
     pan(pan: PanAmount, scales?: Scale[], mode?: UpdateMode): void;
     zoom(zoom: ZoomAmount, useTransition?: boolean, mode?: UpdateMode): void;
-    zoomScale(id: string, min: number, max: number, mode?: UpdateMode): void;
+    zoomScale(id: string, range: ScaleRange, mode?: UpdateMode): void;
     resetZoom(mode?: UpdateMode): void;
   }
 }
@@ -30,5 +32,5 @@ export default Zoom;
 
 export function pan(chart: Chart, amount: PanAmount, scales?: Scale[], mode?: UpdateMode): void;
 export function zoom(chart: Chart, amount: ZoomAmount, mode?: UpdateMode): void;
-export function zoomScale(chart: Chart, scaleId: string, min: number, max: number, mode?: UpdateMode): void;
+export function zoomScale(chart: Chart, scaleId: string, range: ScaleRange, mode?: UpdateMode): void;
 export function resetZoom(chart: Chart, mode?: UpdateMode): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, ChartType, Chart, Scale } from 'chart.js';
+import { Plugin, ChartType, Chart, Scale, UpdateMode } from 'chart.js';
 import { DistributiveArray } from 'chart.js/types/utils';
 import { ZoomPluginOptions } from './options';
 
@@ -10,11 +10,17 @@ declare module 'chart.js' {
 	interface PluginOptionsByType<TType extends ChartType> {
     zoom: ZoomPluginOptions;
   }
+
+  enum UpdateModeEnum {
+    zoom = 'zoom'
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface Chart<TType extends keyof ChartTypeRegistry = keyof ChartTypeRegistry, TData = DistributiveArray<ChartTypeRegistry[TType]['defaultDataPoint']>, TLabel = unknown> {
-    pan(pan: PanAmount, scales?: Scale[]): void;
-    zoom(zoom: ZoomAmount, useTransition?: boolean): void;
-    resetZoom(): void;
+    pan(pan: PanAmount, scales?: Scale[], mode?: UpdateMode): void;
+    zoom(zoom: ZoomAmount, useTransition?: boolean, mode?: UpdateMode): void;
+    zoomScale(id: string, min: number, max: number, mode?: UpdateMode): void;
+    resetZoom(mode?: UpdateMode): void;
   }
 }
 
@@ -22,6 +28,7 @@ declare const Zoom: Plugin;
 
 export default Zoom;
 
-export function doPan(chart: Chart, pan: PanAmount, scales?: Scale[]): void;
-export function doZoom(chart: Chart, zoom: ZoomAmount, useTransition?: boolean): void;
-export function resetZoom(chart: Chart): void;
+export function pan(chart: Chart, amount: PanAmount, scales?: Scale[], mode?: UpdateMode): void;
+export function zoom(chart: Chart, amount: ZoomAmount, mode?: UpdateMode): void;
+export function zoomScale(chart: Chart, scaleId: string, min: number, max: number, mode?: UpdateMode): void;
+export function resetZoom(chart: Chart, mode?: UpdateMode): void;

--- a/types/tests/exports.ts
+++ b/types/tests/exports.ts
@@ -1,5 +1,5 @@
 import { Chart } from 'chart.js';
-import Zoom, { doPan, doZoom, resetZoom } from '../index';
+import Zoom, {pan, zoom, resetZoom } from '../index';
 
 Chart.register(Zoom);
 Chart.unregister(Zoom);
@@ -49,6 +49,6 @@ chart.zoom({ x: 1, y: 1.1, focalPoint: { x: 10, y: 10 } }, true);
 chart.pan(10);
 chart.pan({ x: 10, y: 20 }, [chart.scales.x]);
 
-doPan(chart, -42);
-doZoom(chart, { x: 1, y: 1.1, focalPoint: { x: 10, y: 10 } }, true);
-resetZoom(chart);
+pan(chart, -42, undefined, 'zoom');
+zoom(chart, { x: 1, y: 1.1, focalPoint: { x: 10, y: 10 } }, 'zoom');
+resetZoom(chart, 'none');


### PR DESCRIPTION
Resolves #126 

I was about to just document setting the `min` and `max` + `chart.update()` method, but that way you lose the ability to reset zoom to previous value. So concluded its better to have that functionality built-in.

* Add `zoomScale` export and chart instance function
* Add sample usage of `zoomScale`
* Rename exported `doPan` to `pan` and `doZoom` to `zoom` for consistency with instance API.
* Add any transition mode support to all of these methods
* Add augmentation of `UpdateModeEnum` to include `'zoom'`