### PR TITLE
Expose zoomFunctions and panFunctions for customization

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,6 +2,7 @@ import Hammer from 'hammerjs';
 import {addListeners, computeDragRect, removeListeners} from './handlers';
 import {startHammer, stopHammer} from './hammer';
 import {doPan, doZoom, resetZoom} from './core';
+import {panFunctions, zoomFunctions} from './scale.types';
 import {getState, removeState} from './state';
 import {version} from '../package.json';
 
@@ -83,5 +84,9 @@ export default {
       stopHammer(chart);
     }
     removeState(chart);
-  }
+  },
+
+  panFunctions,
+
+  zoomFunctions
 };

--- a/test/specs/module.spec.js
+++ b/test/specs/module.spec.js
@@ -7,6 +7,11 @@ describe('module', function() {
     expect(window.ChartZoom.id).toBe('zoom');
   });
 
+  it ('should expose zoomFunctions and panFunctions', function() {
+    expect(window.ChartZoom.zoomFunctions instanceof Object).toBe(true);
+    expect(window.ChartZoom.panFunctions instanceof Object).toBe(true);
+  });
+
   it ('should be globally registered', function() {
     const plugin = Chart.registry.getPlugin('zoom');
     expect(plugin).toBe(window.ChartZoom);


### PR DESCRIPTION
I'm tying to upgrade [chartjs-plugin-streaming](https://github.com/nagix/chartjs-plugin-streaming) for Chart.js 3.x and chartjs-plugin-zoom 1.x, but the latest code doesn't expose `zoomFunctions` or `panFunctions` which are required to support new scale types. So, this PR adds these internal objects to the plugin object as properties.