### PR TITLE
Make resetZoom accept UpdateMode argument

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -37,7 +37,7 @@ export default {
     chart.pan = (delta, panScales, transition) => pan(chart, delta, panScales, transition);
     chart.zoom = (args, transition) => zoom(chart, args, transition);
     chart.zoomScale = (id, range, transition) => zoomScale(chart, id, range, transition);
-    chart.resetZoom = () => resetZoom(chart);
+    chart.resetZoom = (transition) => resetZoom(chart, transition);
   },
 
   beforeEvent(chart, args) {


### PR DESCRIPTION
This PR makes `chart.resetZoom` accept the [`UpdateMode`](https://www.chartjs.org/docs/master/api/enums/updatemodeenum.html) argument so that application developers can control animations when they call it.