### PR TITLE
Remove speed property from pan options in the samples

### DIFF
--- a/docs/samples/wheel/category.md
+++ b/docs/samples/wheel/category.md
@@ -60,7 +60,6 @@ const config = {
         pan: {
           enabled: true,
           mode: 'xy',
-          speed: 2,
           threshold: 5,
         },
         zoom: {


### PR DESCRIPTION
Removes the `speed` property from `pan` options in the category scale example because is not supported anymore and it could misleading for who is reading the sample.