### PR TITLE
Fix: modifierKey is not required to end panning

### DIFF
--- a/src/hammer.js
+++ b/src/hammer.js
@@ -16,7 +16,7 @@ function createEnabler(chart) {
     }
     const modifierKey = panOptions.modifierKey;
     const requireModifier = modifierKey && (event.pointerType === 'mouse');
-    if (requireModifier && !event.srcEvent[modifierKey + 'Key']) {
+    if (!state.panning && requireModifier && !event.srcEvent[modifierKey + 'Key']) {
       call(panOptions.onPanRejected, [{chart, event}]);
       return false;
     }


### PR DESCRIPTION
Fixes the bug described by @pmbert in #525 
The threshold bug is on drag-zoom, so the main issue in 525 is not fixed by this.