### PR TITLE
Fix: drag below threshold left dragging state on

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -106,6 +106,8 @@ export function mouseUp(chart, event) {
   state.dragStart = state.dragEnd = null;
 
   if (distance <= threshold) {
+    state.dragging = false;
+    chart.update('none');
     return;
   }
 


### PR DESCRIPTION
Fix #525

The `dragging` was left true and plugin kept rejecting all events to chart after that. The update is needed to remove the rectangle drawn.