### PR TITLE
Add .gitignore from Chart.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,29 @@
-.DS_Store
+# Deployment
+/coverage
+/custom
+/dist
+/gh-pages
 
-node_modules/*
-custom/*
+# Node.js
+node_modules/
+npm-debug.log*
 
-coverage/*
-
-nbproject/*
-dist/
-
+# Docs
+.cache-loader
+build/
 # generated typedocs
 docs/api
+
+# Development
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.idea
+.project
+.settings
+.vscode
+*.log
+*.swp
+*.stackdump


### PR DESCRIPTION
This is also quite close to the .gitignore from chartjs-plugin-annotation, so it helps bring the various Chart.js projects more in sync.  And it keeps my `.vscode` directory from showing up in Git's list of changes.