### PR TITLE
Add a modifierKey for drag-to-zoom

### DIFF
--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -76,6 +76,7 @@ const chart = new Chart('id', {
 | `borderColor` | `Color` | `'rgba(225,225,225)'` | Stroke color
 | `borderWidth` | `number` | `0` | Stroke width
 | `threshold` | `number` | `0` | Minimal zoom distance required before actually applying zoom
+| `modifierKey` | `'ctrl'`\|`'alt'`\|`'shift'`\|`'meta'` | `null` |  Modifier key required for drag-to-zoom
 
 #### Pinch options
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -48,7 +48,8 @@ export function mouseDown(chart, event) {
   const state = getState(chart);
   const {pan: panOptions, zoom: zoomOptions} = state.options;
   const panKey = panOptions && panOptions.modifierKey;
-  if (panKey && event[panKey + 'Key']) {
+  const zoomKey = zoomOptions && zoomOptions.drag && zoomOptions.drag.modifierKey;
+  if ((panKey && event[panKey + 'Key']) || (zoomKey && !event[zoomKey + 'Key'])) {
     return call(zoomOptions.onZoomRejected, [{chart, event}]);
   }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -25,7 +25,8 @@ export default {
         modifierKey: null
       },
       drag: {
-        enabled: false
+        enabled: false,
+        modifierKey: null
       },
       pinch: {
         enabled: false

--- a/test/specs/defaults.spec.js
+++ b/test/specs/defaults.spec.js
@@ -13,7 +13,8 @@ describe('defaults', function() {
         modifierKey: null
       },
       drag: {
-        enabled: false
+        enabled: false,
+        modifierKey: null
       },
       pinch: {
         enabled: false

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -47,6 +47,11 @@ export interface DragOptions {
    * Background color of the drag area
    */
   backgroundColor?: Color;
+
+  /**
+   * Modifier key required for drag-to-zoom
+   */
+  modifierKey?: Key;
 }
 
 export interface PinchOptions {


### PR DESCRIPTION
This PR adds the `modifierKey` option to `zoom.drag`, in a similar fashion to how it works for panning and wheel zooming.

Note: by some hilarious coincidence it looks like @kurkle had the exact same idea today and beat me by 4 hours to add this 😂 I noticed that I had a couple of changes not included in his PR, so I've decided to add my MR as well. I'm perfectly fine with either PR getting merged: I care more about the feature being there than getting my code merged 😉.