### PR TITLE
Fix initial zoom level and pan with drag modifier

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -152,9 +152,11 @@ export function getZoomLevel(chart) {
   let max = 1;
   each(chart.scales, function(scale) {
     const origRange = getOriginalRange(state, scale.id);
-    const level = Math.round(origRange / (scale.max - scale.min) * 100) / 100;
-    min = Math.min(min, level);
-    max = Math.max(max, level);
+    if (origRange) {
+      const level = Math.round(origRange / (scale.max - scale.min) * 100) / 100;
+      min = Math.min(min, level);
+      max = Math.max(max, level);
+    }
   });
   return min < 1 ? min : max;
 }

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -15,7 +15,7 @@ function createEnabler(chart, state) {
       return true;
     }
     if (!state.panning && event.pointerType === 'mouse' && (
-      keyNotPressed(getModifierKey(panOptions), srcEvent) || keyPressed(getModifierKey(zoomOptions), srcEvent))
+      keyNotPressed(getModifierKey(panOptions), srcEvent) || keyPressed(getModifierKey(zoomOptions.drag), srcEvent))
     ) {
       call(panOptions.onPanRejected, [{chart, event}]);
       return false;


### PR DESCRIPTION
- On chart init, the getZoomLevel returned `NaN` because there were no original scale limits stored yet.
- The modifier key for drag-to-zoom was looked from the wrong place