### PR TITLE
Avoid zooming in when zooming out over certain areas of chart

### DIFF
--- a/src/scale.types.js
+++ b/src/scale.types.js
@@ -6,18 +6,12 @@ function zoomDelta(scale, zoom, center) {
   const newRange = range * (zoom - 1);
 
   const centerPoint = scale.isHorizontal() ? center.x : center.y;
-  // `scale.getValueForPixel()` can return a value
-  // less than the minimum value
-  // and greater than the maximum value
-  // when `centerPoint` is past the minimum/maximum values
-  // (e.g., on the y-axis labels).
-  const minPercent = Math.max(
-    0,
-    Math.min(
-      1,
-      (scale.getValueForPixel(centerPoint) - scale.min) / range || 0
-    )
-  );
+  // `scale.getValueForPixel()` can return a value less than the `scale.min` or
+  // greater than `scale.max` when `centerPoint` is outside chartArea.
+  const minPercent = Math.max(0, Math.min(1,
+    (scale.getValueForPixel(centerPoint) - scale.min) / range || 0
+  ));
+
   const maxPercent = 1 - minPercent;
 
   return {

--- a/src/scale.types.js
+++ b/src/scale.types.js
@@ -6,7 +6,18 @@ function zoomDelta(scale, zoom, center) {
   const newRange = range * (zoom - 1);
 
   const centerPoint = scale.isHorizontal() ? center.x : center.y;
-  const minPercent = (scale.getValueForPixel(centerPoint) - scale.min) / range || 0;
+  // `scale.getValueForPixel()` can return a value
+  // less than the minimum value
+  // and greater than the maximum value
+  // when `centerPoint` is past the minimum/maximum values
+  // (e.g., on the y-axis labels).
+  const minPercent = Math.max(
+    0,
+    Math.min(
+      1,
+      (scale.getValueForPixel(centerPoint) - scale.min) / range || 0
+    )
+  );
   const maxPercent = 1 - minPercent;
 
   return {


### PR DESCRIPTION
Zooming out when hovering over y-axis labels or legend (`position: "right"`) would cause `minPercent` to be negative or past 100%, causing the chart to zoom in instead.

Reproduced with a line chart using dates for the x axis. Plugin settings:

```javascript
{
    zoom: {
        pan: {
            enabled: true,
            mode: "x"
        },
        limits: {
            x: {
                min: "original",
                max: "original",
                minRange: 7 * 24 * 60 * 60 * 1000
            }
        },
        zoom: {
            wheel: {
                enabled: true,
            },
            pinch: {
                enabled: true
            },
            mode: 'x'
        }
    }
}