### PR TITLE
Fix initial call to isZoomedOrPanned

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -218,11 +218,11 @@ export function isZoomedOrPanned(chart) {
   for (const scaleId of Object.keys(chart.scales)) {
     const {min: originalMin, max: originalMax} = scaleBounds[scaleId];
 
-    if (chart.scales[scaleId].min !== originalMin) {
+    if (originalMin !== undefined && chart.scales[scaleId].min !== originalMin) {
       return true;
     }
 
-    if (chart.scales[scaleId].max !== originalMax) {
+    if (originalMax !== undefined && chart.scales[scaleId].max !== originalMax) {
       return true;
     }
   }

--- a/test/specs/api.spec.js
+++ b/test/specs/api.spec.js
@@ -142,6 +142,8 @@ describe('api', function() {
         }
       });
 
+      expect(chart.isZoomedOrPanned()).toBe(false);
+
       chart.zoom(1);
       expect(chart.isZoomedOrPanned()).toBe(false);
 
@@ -171,6 +173,8 @@ describe('api', function() {
           }
         }
       });
+
+      expect(chart.isZoomedOrPanned()).toBe(false);
 
       chart.pan({x: 0, y: 0});
       expect(chart.isZoomedOrPanned()).toBe(false);


### PR DESCRIPTION
isZoomedOrPanned incorrectly returns true if it's called before any zoom or pan operations are done.

I believe that the `!== undefined` check should be valid; storeOriginalScaleLimits always sets the min/max value to chart.scales[scaleId]'s min/max, which TypeScript says are always defined. However, I could be missing something.

Fixes #629