### PR TITLE
Only drag zoom on left mouse button

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -52,7 +52,11 @@ function zoomStart(chart, event, zoomOptions) {
 export function mouseDown(chart, event) {
   const state = getState(chart);
   const {pan: panOptions, zoom: zoomOptions = {}} = state.options;
-  if (keyPressed(getModifierKey(panOptions), event) || keyNotPressed(getModifierKey(zoomOptions.drag), event)) {
+  if (
+    event.button !== 0 ||
+    keyPressed(getModifierKey(panOptions), event) ||
+    keyNotPressed(getModifierKey(zoomOptions.drag), event)
+  ) {
     return call(zoomOptions.onZoomRejected, [{chart, event}]);
   }
 


### PR DESCRIPTION
This makes drag act the same as pan (which is implemented by Hammer.js, which - as far as I can tell - automatically only listens to the left / primary mouse button).

By default, right-click is intercepted by the browser to display a context menu, so this isn't noticeable,  However, if `oncontextmenu` is used to disable that (e.g., to use JS to display a menu instead), then right-click can trigger zoom, which feels strange.