### PR TITLE
Allow canceling drag-to-zoom on Escape key

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -34,6 +34,18 @@ export function mouseMove(chart, event) {
   }
 }
 
+function keyDown(chart, event) {
+  const state = getState(chart);
+  if (!state.dragStart || event.key !== 'Escape') {
+    return;
+  }
+
+  removeHandler(chart, 'keydown');
+  state.dragging = false;
+  state.dragStart = state.dragEnd = null;
+  chart.update('none');
+}
+
 function zoomStart(chart, event, zoomOptions) {
   const {onZoomStart, onZoomRejected} = zoomOptions;
   if (onZoomStart) {
@@ -62,6 +74,7 @@ export function mouseDown(chart, event) {
   state.dragStart = event;
 
   addHandler(chart, chart.canvas, 'mousemove', mouseMove);
+  addHandler(chart, window.document, 'keydown', keyDown);
 }
 
 export function computeDragRect(chart, mode, beginPoint, endPoint) {
@@ -197,6 +210,7 @@ export function addListeners(chart, options) {
     removeHandler(chart, 'mousedown');
     removeHandler(chart, 'mousemove');
     removeHandler(chart, 'mouseup');
+    removeHandler(chart, 'keydown');
   }
 }
 
@@ -206,4 +220,5 @@ export function removeListeners(chart) {
   removeHandler(chart, 'mouseup');
   removeHandler(chart, 'wheel');
   removeHandler(chart, 'click');
+  removeHandler(chart, 'keydown');
 }


### PR DESCRIPTION
This makes the behavior of drag-to-zoom closer to the browser's standard drag-and-drop behavior.