### PR TITLE
Modify UpdateModeEnum to not be const

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "babel-loader": "^8.3.0",
-        "chart.js": "^4.0.1",
+        "chart.js": "^4.2.1",
         "chartjs-adapter-date-fns": "^2.0.1",
         "chartjs-test-utils": "^0.3.0",
         "concurrently": "^6.0.2",
@@ -2048,6 +2048,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
+      "dev": true
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -5419,10 +5425,13 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.0.1.tgz",
-      "integrity": "sha512-5/8/9eBivwBZK81mKvmIwTb2Pmw4D/5h1RK9fBWZLLZ8mCJ+kfYNmV9rMrGoa5Hgy2/wVDBMLSUDudul2/9ihA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
       "dev": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
       "engines": {
         "pnpm": "^7.0.0"
       }
@@ -20549,6 +20558,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -23291,10 +23306,13 @@
       "dev": true
     },
     "chart.js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.0.1.tgz",
-      "integrity": "sha512-5/8/9eBivwBZK81mKvmIwTb2Pmw4D/5h1RK9fBWZLLZ8mCJ+kfYNmV9rMrGoa5Hgy2/wVDBMLSUDudul2/9ihA==",
-      "dev": true
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "dev": true,
+      "requires": {
+        "@kurkle/color": "^0.3.0"
+      }
     },
     "chartjs-adapter-date-fns": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "babel-loader": "^8.3.0",
-    "chart.js": "^4.0.1",
+    "chart.js": "^4.2.1",
     "chartjs-adapter-date-fns": "^2.0.1",
     "chartjs-test-utils": "^0.3.0",
     "concurrently": "^6.0.2",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ declare module 'chart.js' {
     zoom: ZoomPluginOptions;
   }
 
-  const enum UpdateModeEnum {
+  enum UpdateModeEnum {
     zoom = 'zoom'
   }
 


### PR DESCRIPTION
Closes https://github.com/chartjs/chartjs-plugin-zoom/issues/735
Closes https://github.com/chartjs/chartjs-plugin-zoom/issues/721
Closes https://github.com/chartjs/chartjs-plugin-zoom/issues/731

This enum was changed to a normal enum instead of using const in https://github.com/chartjs/Chart.js/pull/11095, so the type is no longer matching with Chart.js.