### PR TITLE
Fix "original" scale limits with nonlinear pan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "babel-loader": "^8.3.0",
-        "chart.js": "^4.2.1",
+        "chart.js": "^4.3.2",
         "chartjs-adapter-date-fns": "^2.0.1",
         "chartjs-test-utils": "^0.3.0",
         "concurrently": "^6.0.2",
@@ -5428,15 +5428,15 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
-      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.2.tgz",
+      "integrity": "sha512-pvQNyFOY1QmbmIr8oDORL16/FFivfxj8V26VFpFilMo4cNvkV5WXLJetDio365pd9gKUHGdirUTbqJfw8tr+Dg==",
       "dev": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
-        "pnpm": "^7.0.0"
+        "pnpm": ">=7"
       }
     },
     "node_modules/chartjs-adapter-date-fns": {
@@ -23314,9 +23314,9 @@
       "dev": true
     },
     "chart.js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
-      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.2.tgz",
+      "integrity": "sha512-pvQNyFOY1QmbmIr8oDORL16/FFivfxj8V26VFpFilMo4cNvkV5WXLJetDio365pd9gKUHGdirUTbqJfw8tr+Dg==",
       "dev": true,
       "requires": {
         "@kurkle/color": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "babel-loader": "^8.3.0",
-    "chart.js": "^4.2.1",
+    "chart.js": "^4.3.2",
     "chartjs-adapter-date-fns": "^2.0.1",
     "chartjs-test-utils": "^0.3.0",
     "concurrently": "^6.0.2",

--- a/src/scale.types.js
+++ b/src/scale.types.js
@@ -1,6 +1,19 @@
 import {valueOrDefault} from 'chart.js/helpers';
 import {getState} from './state';
 
+/**
+ * @typedef {import('chart.js').Point} Point
+ * @typedef {import('chart.js').Scale} Scale
+ * @typedef {import('../types/options').LimitOptions} LimitOptions
+ * @typedef {{min: number, max: number}} ScaleRange
+ */
+
+/**
+ * @param {Scale} scale
+ * @param {number} zoom
+ * @param {Point} center
+ * @returns {ScaleRange}
+ */
 function zoomDelta(scale, zoom, center) {
   const range = scale.max - scale.min;
   const newRange = range * (zoom - 1);
@@ -29,6 +42,12 @@ function getLimit(state, scale, scaleLimits, prop, fallback) {
   return valueOrDefault(limit, fallback);
 }
 
+/**
+ * @param {Scale} scale
+ * @param {number} pixel0
+ * @param {number} pixel1
+ * @returns {ScaleRange}
+ */
 function getRange(scale, pixel0, pixel1) {
   const v0 = scale.getValueForPixel(pixel0);
   const v1 = scale.getValueForPixel(pixel1);
@@ -38,6 +57,13 @@ function getRange(scale, pixel0, pixel1) {
   };
 }
 
+/**
+ * @param {Scale} scale
+ * @param {ScaleRange} limits
+ * @param {LimitOptions} limits
+ * @param {boolean} zoom
+ * @returns {boolean}
+ */
 export function updateRange(scale, {min, max}, limits, zoom = false) {
   const state = getState(scale.chart);
   const {id, axis, options: scaleOpts} = scale;

--- a/test/specs/pan.spec.js
+++ b/test/specs/pan.spec.js
@@ -124,6 +124,77 @@ describe('pan', function() {
       expect(scale.options.min).toBe(2);
       expect(scale.options.max).toBe(2);
     });
+
+    it('should respect original limits', function() {
+      const chart = window.acquireChart({
+        type: 'line',
+        data,
+        options: {
+          plugins: {
+            zoom: {
+              pan: {
+                enabled: true,
+                mode: 'x',
+              },
+              limits: {
+                x: {
+                  min: 'original',
+                  max: 'original',
+                }
+              },
+            }
+          },
+          scales: {
+            x: {
+              min: 1,
+              max: 2
+            }
+          }
+        }
+      });
+      const scale = chart.scales.x;
+      expect(scale.min).toBe(1);
+      expect(scale.max).toBe(2);
+      chart.pan(100);
+      expect(scale.min).toBe(1);
+      expect(scale.max).toBe(2);
+    });
+
+    it('should respect original limits for nonlinear scales', function() {
+      const chart = window.acquireChart({
+        type: 'line',
+        data,
+        options: {
+          plugins: {
+            zoom: {
+              pan: {
+                enabled: true,
+                mode: 'x',
+              },
+              limits: {
+                x: {
+                  min: 'original',
+                  max: 'original',
+                }
+              },
+            }
+          },
+          scales: {
+            x: {
+              type: 'logarithmic',
+              min: 1,
+              max: 10
+            }
+          }
+        }
+      });
+      const scale = chart.scales.x;
+      expect(scale.min).toBe(1);
+      expect(scale.max).toBe(10);
+      chart.pan(100);
+      expect(scale.min).toBe(1);
+      expect(scale.max).toBe(10);
+    });
   });
 
   describe('events', function() {


### PR DESCRIPTION
Nonlinear scales failed to resolve "original" within panNumericalScale.

To fix this:

* Resolving "original" within panNumericalScale seemed redundant, when updateRange was already doing it, so I instead moved the logic into updateRange and control it with a new special value for the `zoom` parameter.  (Hopefully the use of a special string like this is acceptable as long as JSDoc calls it out - if I should use another approach, please let me know.)
* This change put updateRange over the configured ESLint complexity limit, so I extracted a new getScaleLimits function to reduce complexity.

Add unit tests, both for this bug and for the preexisting but untested    "original" feature.

I wanted JSDoc + TypeScript checks to help validate and document these changes, but that exposed apparent limitations of Chart.js core's type definitions. I'll open a separate PR for those.