### PR TITLE
fix: typo in drag options documentation

### DIFF
--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -77,7 +77,7 @@ const chart = new Chart('id', {
 | `backgroundColor` | `Color` | `'rgba(225,225,225,0.3)'` | Fill color
 | `borderColor` | `Color` | `'rgba(225,225,225)'` | Stroke color
 | `borderWidth` | `number` | `0` | Stroke width
-| [`drawTime`](#draw-time) | `string` | `beforeDatasetsDraw` | When the dragging box is dran on the chart
+| [`drawTime`](#draw-time) | `string` | `beforeDatasetsDraw` | When the dragging box is drawn on the chart
 | `threshold` | `number` | `0` | Minimal zoom distance required before actually applying zoom
 | `modifierKey` | `'ctrl'`\|`'alt'`\|`'shift'`\|`'meta'` | `null` |  Modifier key required for drag-to-zoom
 


### PR DESCRIPTION
## Before:
`When the dragging box is dran on the chart`

## After:
`When the dragging box is drawn on the chart`