### PR TITLE
fix: trigger `onZoomStart` from `pinchStart`

### DIFF
--- a/src/hammer.js
+++ b/src/hammer.js
@@ -68,6 +68,7 @@ function handlePinch(chart, state, e) {
 
 function startPinch(chart, state) {
   if (state.options.zoom.pinch.enabled) {
+    call(state.options.zoom.onZoomStart, [{chart}]);
     state.scale = 1;
   }
 }


### PR DESCRIPTION
this simply ensures that the custom `onZoomStart` handler is also executed when zooming is initiated with "pinch".

there seems to be a fair difference in the logic structure between the `handlers.js` and `hammer.js` files, so I tried to keep this in line with what I already saw in `hammer.js` directly.

I did not add any tests for this, though I feel like we probably should.. perhaps one of the repo maintainers could help determine where this test should go? I don't see any others that cover the "pinch" functionality specifically.

this follows on from PR #487, and fixes issues #631 and #790.