### PR TITLE
fixed missing args to onZoomComplete callback

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -181,9 +181,7 @@ export function wheel(chart, event) {
 
   zoom(chart, amount);
 
-  if (onZoomComplete) {
-    onZoomComplete();
-  }
+  call(onZoomComplete, [{chart}]);
 }
 
 function addDebouncedHandler(chart, name, handler, delay) {


### PR DESCRIPTION
Adds missing args to `onZoomComplete` callback and calls it properly