### PR TITLE
Pin karma-rollup-preprocessor to 7.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "karma-firefox-launcher": "^2.1.3",
         "karma-jasmine": "^5.1.0",
         "karma-jasmine-html-reporter": "^2.1.0",
-        "karma-rollup-preprocessor": "^7.0.7",
+        "karma-rollup-preprocessor": "7.0.7",
         "karma-spec-reporter": "0.0.36",
         "ng-hammerjs": "^2.0.8",
         "pixelmatch": "^6.0.0",
@@ -12644,10 +12644,11 @@
       "dev": true
     },
     "node_modules/karma-rollup-preprocessor": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.8.tgz",
-      "integrity": "sha512-WiuBCS9qsatJuR17dghiTARBZ7LF+ml+eb7qJXhw7IbsdY0lTWELDRQC/93J9i6636CsAXVBL3VJF4WtaFLZzA==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.7.tgz",
+      "integrity": "sha512-Y1QwsTCiCBp8sSALZdqmqry/mWIWIy0V6zonUIpy+0/D/Kpb2XZvR+JZrWfacQvcvKQdZFJvg6EwlnKtjepu3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.3.1",
         "debounce": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "karma-firefox-launcher": "^2.1.3",
     "karma-jasmine": "^5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",
-    "karma-rollup-preprocessor": "^7.0.7",
+    "karma-rollup-preprocessor": "7.0.7",
     "karma-spec-reporter": "0.0.36",
     "ng-hammerjs": "^2.0.8",
     "pixelmatch": "^6.0.0",


### PR DESCRIPTION
7.0.8 apparently introduces a bug where running in watch mode (`npm run dev`) causes `test/index.js` to be endlessly overwritten: https://github.com/jlmakes/karma-rollup-preprocessor/issues/75