### PR TITLE
Switch coverallsapp action to use a  tag version instead of deprecated master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       shell: bash
 
     - name: Coveralls Parallel - Chrome
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         path-to-lcov: './coverage/chrome/lcov.info'
@@ -49,7 +49,7 @@ jobs:
         parallel: true
 
     - name: Coveralls Parallel - Firefox
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         path-to-lcov: './coverage/firefox/lcov.info'
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
-        path-to-lcov: './coverage/chrome/lcov.info'
+        file: './coverage/chrome/lcov.info'
         flag-name: ${{ matrix.os }}-chrome
         parallel: true
 
@@ -52,7 +52,7 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
-        path-to-lcov: './coverage/firefox/lcov.info'
+        file: './coverage/firefox/lcov.info'
         flag-name: ${{ matrix.os }}-firefox
         parallel: true
 


### PR DESCRIPTION
I noticed the `CI` workflow uses `coverallsapp/github-action@master` but this caused warnings of outdated `node`version
![2024-11-22_21-41](https://github.com/user-attachments/assets/5e2554d9-92af-412a-a2de-ca13056ca58f)

Checking the repo, I found this thread: https://github.com/coverallsapp/github-action/issues/201 which described that they switched from `master` to `main` a year ago (https://github.com/coverallsapp/github-action/issues/201#issuecomment-2234228863).

This PR updated the workflow file to use a tagged version of `coverallsapp` instead of the deprecated `master` branch