### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:23-alpine3.19
+RUN apk add --no-cache \
+                git \
+                nano\
+                openssh
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "chartjs-plugin-zoom devcontainer",
+  "dockerFile": "Dockerfile",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "npm install",
+    "customizations": {
+      // Configure properties specific to VS Code.
+        "vscode": {
+          "settings": {},
+          "extensions": [
+            "eamodio.gitlens",
+            "EditorConfig.EditorConfig"
+          ]
+        }
+    },
+  "containerEnv": {
+    "GIT_EDITOR": "nano"
+  },
+  "mounts": [
+    "type=bind,source=/home/${localEnv:USER}/.ssh,target=/home/node/.ssh,readonly"
+  ]
+}


### PR DESCRIPTION
This adds a simple Devcontainer which eases contribution without needing to install all dependencies locally. 
This can be used e.g. in VSCode to have a reproducible build environment. 
https://code.visualstudio.com/docs/devcontainers/containers