### PR TITLE
Remove unnecessary chart updates on drags

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -45,7 +45,7 @@ export function mouseMove(chart: Chart, event: MouseEvent) {
   if (state.dragStart) {
     state.dragging = true
     state.dragEnd = event
-    chart.draw();
+    chart.draw()
   }
 }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -45,7 +45,7 @@ export function mouseMove(chart: Chart, event: MouseEvent) {
   if (state.dragStart) {
     state.dragging = true
     state.dragEnd = event
-    chart.update('none')
+    chart.draw();
   }
 }
 
@@ -58,7 +58,7 @@ function keyDown(chart: Chart, event: KeyboardEvent) {
   removeHandler(chart, 'keydown')
   state.dragging = false
   state.dragStart = state.dragEnd = undefined
-  chart.update('none')
+  chart.draw();
 }
 
 function getPointPosition(event: MouseEvent, chart: Chart) {
@@ -203,12 +203,12 @@ export function mouseUp(chart: Chart, event: MouseEvent) {
   const distanceY = directionEnabled(mode, 'y', chart) ? rect.height : 0
   const distance = Math.sqrt(distanceX * distanceX + distanceY * distanceY)
 
-  // Remove drag start and end before chart update to stop drawing selected area
+  // Remove drag start and end before chart render to stop drawing selected area
   state.dragStart = state.dragEnd = undefined
 
   if (distance <= threshold) {
     state.dragging = false
-    chart.update('none')
+    chart.draw();
     return
   }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -58,7 +58,7 @@ function keyDown(chart: Chart, event: KeyboardEvent) {
   removeHandler(chart, 'keydown')
   state.dragging = false
   state.dragStart = state.dragEnd = undefined
-  chart.draw();
+  chart.draw()
 }
 
 function getPointPosition(event: MouseEvent, chart: Chart) {
@@ -208,7 +208,7 @@ export function mouseUp(chart: Chart, event: MouseEvent) {
 
   if (distance <= threshold) {
     state.dragging = false
-    chart.draw();
+    chart.draw()
     return
   }
 


### PR DESCRIPTION
Changes a few `chart.update()` calls in the zoom drag handler (i.e. mouse down, mouse move, mouse up) to just use `chart.draw()` instead. The chart update was unnecessary since none of the chart elements had updated. It is also much more expensive to update the chart (incurring costs of things like recomputing the ticks, recomputing any datapoint styling using chart context, etc.) than just to redraw the chart. In some cases with lots of datapoints, this speeds up the function from 100ms -> 1ms. As far as I can tell, the only purpose of the `chart.update()` call was to repaint the shaded area being zoomed, but `chart.draw()` achieves the same purpose.