### PR TITLE
Update Chart.js and simplify types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@typescript-eslint/parser": "^5.62.0",
         "babel-loader": "^8.3.0",
         "c8": "^10.1.2",
-        "chart.js": "^4.3.2",
+        "chart.js": "^4.4.8",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-test-utils": "^0.5.0",
         "concurrently": "^9.1.0",
@@ -7536,10 +7536,11 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.6.tgz",
-      "integrity": "sha512-8Y406zevUPbbIBA/HRk33khEmQPk5+cxeflWE/2rx1NJsjVWMPw/9mSP9rxHP5eqi6LNoPBVMfZHxbwLSgldYA==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+      "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@typescript-eslint/parser": "^5.62.0",
     "babel-loader": "^8.3.0",
     "c8": "^10.1.2",
-    "chart.js": "^4.3.2",
+    "chart.js": "^4.4.8",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-test-utils": "^0.5.0",
     "concurrently": "^9.1.0",

--- a/src/hammer.ts
+++ b/src/hammer.ts
@@ -73,7 +73,7 @@ function handlePinch(chart: Chart, state: State, e: HammerInput) {
 
 function startPinch(chart: Chart, state: State, e: HammerInput) {
   if (state.options.zoom?.pinch?.enabled) {
-    const point = getRelativePosition(e.srcEvent, chart as any) // TODO: would expect Chart type to be valid for getRelativePosition
+    const point = getRelativePosition(e.srcEvent, chart)
     if (state.options.zoom?.onZoomStart?.({ chart, event: e.srcEvent, point }) === false) {
       state.scale = null
       state.options.zoom?.onZoomRejected?.({ chart, event: e.srcEvent })

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -69,7 +69,7 @@ function getPointPosition(event: MouseEvent, chart: Chart) {
       y: event.clientY - canvasArea.top,
     }
   }
-  return getRelativePosition(event, chart as any) // TODO: would expect Chart type to be valid for getRelativePosition
+  return getRelativePosition(event, chart)
 }
 
 function zoomStart(chart: Chart, event: MouseEvent, zoomOptions: ZoomOptions): boolean | void {
@@ -85,7 +85,7 @@ function zoomStart(chart: Chart, event: MouseEvent, zoomOptions: ZoomOptions): b
 
 export function mouseDown(chart: Chart, event: MouseEvent): void {
   if (chart.legend) {
-    const point = getRelativePosition(event, chart as any) // TODO: would expect Chart type to be valid for getRelativePosition
+    const point = getRelativePosition(event, chart)
     if (_isPointInArea(point, chart.legend)) {
       return
     }


### PR DESCRIPTION
Now that https://github.com/chartjs/Chart.js/pull/12012 has been fixed, these `as any` casts are no longer needed.