### PR TITLE
Extend onZoom and onPan callbacks for syncing multiple charts

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -3,7 +3,7 @@ import { panFunctions, updateRange, zoomFunctions, zoomRectFunctions } from './s
 import { getState, type OriginalScaleLimits, type ScaleRange, type State, type UpdatedScaleLimits } from './state.js'
 import { directionEnabled, getEnabledScalesByPoint } from './utils.js'
 import type { Chart, Point, Scale, UpdateMode } from 'chart.js'
-import type { LimitOptions, ZoomTrigger } from './options.js'
+import type { LimitOptions, PanTrigger, ZoomTrigger } from './options.js'
 import type { ZoomAmount } from './types.js'
 
 function shouldUpdateScaleLimits(
@@ -89,7 +89,7 @@ export function zoom(chart: Chart, amount: ZoomAmount, transition: UpdateMode = 
 
   chart.update(transition)
 
-  zoomOptions?.onZoom?.({ chart, trigger })
+  zoomOptions?.onZoom?.({ chart, trigger, amount: { x, y, focalPoint } })
 }
 
 export function zoomRect(
@@ -207,7 +207,7 @@ function panScale(scale: Scale, delta: number, limits: LimitOptions, state: Stat
 
 type PanAmount = number | Partial<Point>
 
-export function pan(chart: Chart, delta: PanAmount, enabledScales?: Scale[], transition: UpdateMode = 'none') {
+export function pan(chart: Chart, delta: PanAmount, enabledScales?: Scale[], transition: UpdateMode = 'none', trigger: PanTrigger = "other") {
   const { x = 0, y = 0 } = typeof delta === 'number' ? { x: delta, y: delta } : delta
   const state = getState(chart)
   const {
@@ -232,7 +232,7 @@ export function pan(chart: Chart, delta: PanAmount, enabledScales?: Scale[], tra
 
   chart.update(transition)
 
-  onPan?.({ chart })
+  onPan?.({ chart, trigger, delta: { x, y } })
 }
 
 export function getInitialScaleBounds(chart: Chart) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,7 @@ export type ModeOption = Mode | ModeFn
 export type ModifierKey = 'ctrl' | 'alt' | 'shift' | 'meta'
 export type DrawTime = 'afterDraw' | 'afterDatasetsDraw' | 'beforeDraw' | 'beforeDatasetsDraw'
 export type ZoomTrigger = 'api' | 'drag' | 'wheel' | 'pinch'
+export type PanTrigger = 'api' | 'drag' | 'wheel' | 'other'
 
 type RejectableStartEvent<T = Event | HammerInput> = (context: {
   chart: Chart
@@ -120,7 +121,7 @@ export interface ZoomOptions {
   /**
    * Function called while the user is zooming
    */
-  onZoom?: (context: { chart: Chart; trigger: ZoomTrigger }) => void
+  onZoom?: (context: { chart: Chart; trigger: ZoomTrigger; amount?: { x: number, y: number } & { focalPoint: Point } }) => void
 
   /**
    * Function called once zooming is completed
@@ -172,7 +173,7 @@ export interface PanOptions {
   /**
    * Function called while the user is panning
    */
-  onPan?: GenericEvent
+  onPan?: (context: { chart: Chart; trigger: PanTrigger; delta: { x: number, y: number } }) => void
 
   /**
    * Function called once panning is completed

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -50,7 +50,7 @@ function draw(chart: Chart, caller: string, options: ZoomPluginOptions) {
 }
 
 const bindApi = (chart: Chart) => {
-  chart.pan = (delta, panScales, transition) => pan(chart, delta, panScales, transition)
+  chart.pan = (delta, panScales, transition) => pan(chart, delta, panScales, transition, "api")
   chart.zoom = (args, transition) => zoom(chart, args, transition)
   chart.zoomRect = (p0, p1, transition) => zoomRect(chart, p0, p1, transition)
   chart.zoomScale = (id, range, transition) => zoomScale(chart, id, range, transition)


### PR DESCRIPTION
### Purpose
onZoom and onPan callbacks now return additional data that is useful for syncing multiple charts.

### Changes
- `onZoom` returns the amount it zoomed.
- `onPan` returns the delta it panned.

These values can be used to zoom/pan other charts by the same amount.
The values are basically piped through from the function args, so there is no additional computation.

- `pan()` receives a new PanTrigger parameter.

It can be used in the spirit of ZoomTrigger to distinguish between "api" and user interactions.
This is required to pan other charts when the user pans, but not trigger a loop through the subsequent programmatic calls to pan().

### Example
```
function createChart(chart:Chart, chartElement: HTMLCanvasElement) {
  chart = new Chart(chartElement.getContext('2d')!, {
    type: 'line',
    data: { datasets: items },
    options: {
      plugins: {
        zoom: {
          pan: {
            enabled: true,
            mode: 'x',
            onPan: ({ chart, delta, trigger }) => {
              if (trigger === 'api') return;
              Object.values(Chart.instances).forEach((c) => {
                if (c.id !== chart.id) {
                  c.pan({ x: delta.x });
                }
              });
            }
          },
          zoom: {
            wheel: { enabled: true },
            mode: 'xy',
            onZoom: ({ chart, amount, trigger }) => {
              if (trigger === 'api' || amount === undefined) return;
              Object.values(Chart.instances).forEach((c) => {
                if (c.id !== chart.id) {
                  c.zoom(amount);
                }
              });
            }
          },
        },
      },
    }
  });
}
```

### Background
So far there is no good way to sync zoom and pan across multiple charts that I could come up with or have found during my research.

The only approach I found was this from 2019:
https://github.com/chartjs/chartjs-plugin-zoom/issues/238#issuecomment-2002819777

The changes I propose solve the issue of syncing multiple charts in a simple way while not breaking anything.
I think it would be a good addition to the library that could help many others.